### PR TITLE
fix(ci): add pull-requests read permission to PR title check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize]
 
+permissions:
+  pull-requests: read
+
 jobs:
   check-title:
     name: Validate PR Title


### PR DESCRIPTION
## Summary

- Add `permissions: pull-requests: read` to the PR title validation workflow
- The `pull_request_target` event requires explicit permissions for `GITHUB_TOKEN` to access PR data — without it the action fails with "Resource not accessible by integration"

## Test plan

- [ ] This PR's own title check passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)