### PR TITLE
chore: sync Cargo.toml version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr-bro"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- Update Cargo.toml version from `0.1.0` to `0.2.0` to match the existing `v0.2.0` git tag/release
- This was causing release-plz to report "nothing to release" because the version in Cargo.toml was behind the latest tag

## Test plan

- [ ] After merge, next push with a `feat` commit should trigger release-plz to propose `0.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)