### PR TITLE
docs: remove build and release badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # PR Bro
 
-[![CI](https://img.shields.io/github/actions/workflow/status/toniperic/pr-bro/ci.yml?branch=master)](https://github.com/toniperic/pr-bro/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/toniperic/pr-bro)](https://github.com/toniperic/pr-bro/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Know which PR to review next. PR Bro ranks pull requests by weighted scoring across your GitHub queries, so you always start with the most important review.


### PR DESCRIPTION
## Summary

- Remove CI and Release status badges from README.md
- Keep only the License badge
- Reduces visual noise for end users who don't need workflow status info

## Test plan

- [ ] Verify README renders correctly with only the license badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)