### PR TITLE
ci: skip CI checks for PRs with only non-code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,29 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/ci.yml'
+              - 'build.rs'
+
   fmt:
     name: Format Check
+    needs: [changes]
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,6 +46,8 @@ jobs:
 
   clippy:
     name: Clippy Lint
+    needs: [changes]
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +59,8 @@ jobs:
 
   test:
     name: Test Suite
+    needs: [changes]
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,6 +70,8 @@ jobs:
 
   build:
     name: Build Release
+    needs: [changes]
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Add a `changes` detection job using `dorny/paths-filter@v3` to detect code-relevant file changes
- Make all 4 CI jobs (Format Check, Clippy Lint, Test Suite, Build Release) conditional on code changes
- PRs that only touch non-code files (README, docs, LICENSE, etc.) skip expensive Rust CI jobs
- Push to master always runs all checks unconditionally

## How it works

The `changes` job runs `dorny/paths-filter` to check if any of these paths were modified:
- `src/**`, `Cargo.toml`, `Cargo.lock`, `.github/workflows/ci.yml`, `build.rs`

Each CI job uses:
```yaml
needs: [changes]
if: always() && (github.event_name == 'push' || needs.changes.outputs.code == 'true')
```

- **Push to master**: `changes` job is skipped (has `if: pull_request`), but `always()` ensures dependent jobs still evaluate their `if` condition, and `github.event_name == 'push'` fires — all jobs run.
- **PR with code changes**: `changes` detects code files, `needs.changes.outputs.code == 'true'` — all jobs run.
- **PR with only non-code changes**: `needs.changes.outputs.code == 'false'` — all jobs are skipped. GitHub treats skipped required checks as passing.

## Test plan

- [ ] This PR modifies `ci.yml` which is in the code paths filter, so all 4 CI checks should trigger and pass
- [ ] Verify the badges-only PR (#4) would have skipped CI if this was already merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)