### PR TITLE
fix(ci): add git_only to release-plz config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,7 @@
 [workspace]
 git_tag_name = "v{{ version }}"
 git_release_type = "auto"
+git_only = true
 pr_labels = ["release"]
 publish_timeout = "0s"
 


### PR DESCRIPTION
## Summary

- Adds `git_only = true` to `release-plz.toml` so release-plz uses git tags instead of the cargo registry to determine package versions
- Fixes release-plz reporting "nothing to release" after feat commits are merged to master

## Root cause

`pr-bro` has `publish = false` in `Cargo.toml` and is never published to crates.io. By default, release-plz checks the cargo registry to determine the latest version — since it can't find `pr-bro` there, it silently skips version bumps and reports "nothing to release".

With `git_only = true`, release-plz uses git tags (e.g. `v0.2.0`) as the source of truth.

## References

- [release-plz #2512: add `git_only` config option](https://github.com/release-plz/release-plz/pull/2512)
- [release-plz #2602: `release-pr` fails with `publish=false` + `git_only`](https://github.com/release-plz/release-plz/issues/2602)
- [release-plz #2603: fix for private `git_only` packages](https://github.com/release-plz/release-plz/pull/2603)

## Test plan

- [ ] Merge to master and verify release-plz creates a release PR bumping version from 0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)