### PR TITLE
fix(ci): enable crates.io publishing for release-plz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,11 @@
 name = "pr-bro"
 version = "0.2.0"
 edition = "2021"
-publish = false
+description = "Know which PR to review next. Ranks pull requests by weighted scoring."
+license = "MIT"
+repository = "https://github.com/toniperic/pr-bro"
+keywords = ["github", "pull-request", "code-review", "tui", "cli"]
+categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 octocrab = "0.49"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,13 +1,7 @@
 [workspace]
 git_tag_name = "v{{ version }}"
 git_release_type = "auto"
-git_only = true
 pr_labels = ["release"]
-publish_timeout = "0s"
-
-[[package]]
-name = "pr-bro"
-publish = false
 
 [changelog]
 protect_breaking_commits = true


### PR DESCRIPTION
## Summary

- Enables crates.io publishing so release-plz can properly detect versions and create release PRs
- Adds required crate metadata (description, license, repository, keywords, categories)
- Removes `git_only = true` and `publish = false` workarounds

## Why

release-plz's `git_only` mode has an [upstream bug](https://github.com/release-plz/release-plz/issues/2594) where the `release-pr` command still compares against crates.io internally, causing it to log `"local version (0.2.0) > registry version (0.1.0). Only changelog will be updated."` instead of bumping the version to `0.3.0`.

Publishing to crates.io is release-plz's primary and best-tested workflow. This also gives users `cargo install pr-bro` as a bonus install method.

## After merging

1. release-plz will create a release PR bumping to `0.3.0` (based on feat commits since `v0.2.0`)
2. Merging that PR triggers `release-plz release` which publishes to crates.io, creates `v0.3.0` tag, and triggers the cross-platform release workflow
3. **Note:** You'll need a crates.io API token set as a `CARGO_REGISTRY_TOKEN` secret in the repo for publishing to work. Generate one at https://crates.io/settings/tokens

## Test plan

- [x] `cargo package --allow-dirty` succeeds with all required metadata
- [ ] Merge and verify release-plz creates a version-bump PR (not changelog-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)