### PR TITLE
feat: change score breakdown keybind from 'd' to 'b'

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -252,7 +252,7 @@ fn handle_key_event(app: &mut App, key: KeyEvent) {
                 KeyCode::Char('?') => app.show_help(),
 
                 // Score breakdown
-                KeyCode::Char('d') => app.show_score_breakdown(),
+                KeyCode::Char('b') => app.show_score_breakdown(),
 
                 // Dismiss update banner
                 KeyCode::Char('x') => {
@@ -287,7 +287,7 @@ fn handle_key_event(app: &mut App, key: KeyEvent) {
             }
         }
         app::InputMode::ScoreBreakdown => match key.code {
-            KeyCode::Esc | KeyCode::Char('d') => app.dismiss_score_breakdown(),
+            KeyCode::Esc | KeyCode::Char('b') => app.dismiss_score_breakdown(),
             KeyCode::Char('j') | KeyCode::Down => app.next_row(),
             KeyCode::Char('k') | KeyCode::Up => app.previous_row(),
             _ => {}

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -572,7 +572,7 @@ fn render_help_popup(frame: &mut Frame) {
             Span::raw("Open PR in browser"),
         ]),
         Line::from(vec![
-            Span::styled("d             ", Style::default().fg(Color::Cyan).bold()),
+            Span::styled("b             ", Style::default().fg(Color::Cyan).bold()),
             Span::raw("Score breakdown"),
         ]),
         Line::from(vec![


### PR DESCRIPTION
## Summary

- Changes the score breakdown toggle key from `d` to `b`
- Updates keybind handler (open + dismiss) and help legend

## Test plan

- [ ] Press `b` in TUI to open score breakdown
- [ ] Press `b` or `Esc` to dismiss it
- [ ] Press `?` and verify help shows `b` for score breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)