### PR TITLE
fix: update footer hint from 'd' to 'b' for score breakdown

### DIFF
--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -320,7 +320,7 @@ fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
             View::Active => vec![
                 ("j", "/", "k", ":nav "),
                 ("Enter", "", "", ":open "),
-                ("d", "", "", ":detail "),
+                ("b", "", "", ":detail "),
                 ("s", "", "", ":snooze "),
                 ("r", "", "", ":refresh "),
                 ("Tab", "", "", ":snoozed "),
@@ -330,7 +330,7 @@ fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
             View::Snoozed => vec![
                 ("j", "/", "k", ":nav "),
                 ("Enter", "", "", ":open "),
-                ("d", "", "", ":detail "),
+                ("b", "", "", ":detail "),
                 ("s", "", "", ":resnooze "),
                 ("u", "", "", ":unsnooze "),
                 ("r", "", "", ":refresh "),


### PR DESCRIPTION
## Summary

- Updates the footer/status bar hints in both Active and Snoozed views to show `b` instead of `d` for score breakdown

Follows up on #10 which changed the keybind but missed the footer.

## Test plan

- [ ] Footer shows `b:detail` in Active view
- [ ] Footer shows `b:detail` in Snoozed view

🤖 Generated with [Claude Code](https://claude.com/claude-code)