### PR TITLE
fix: update docs references from 'd' to 'b' for score breakdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ Use `pr-bro --help` for all command-line options. Press `?` in the TUI for keybo
 
 **Weighted scoring** calculates a single priority number for each PR based on age, approval count, size, labels, and whether you've reviewed it before, all based on your preferences/configuration. Each parameter can be used to boost or penalize PRs score in any way you see fit.
 
-**Interactive TUI** shows all PRs sorted by score. Navigate with arrow keys or vim bindings. Press `d` to see the score breakdown for any PR. Press `r` to refresh.
+**Interactive TUI** shows all PRs sorted by score. Navigate with arrow keys or vim bindings. Press `b` to see the score breakdown for any PR. Press `r` to refresh.
 
 **Multiple queries** let you track different PR sets. Each query can override global scoring rules. First-match-wins when a PR appears in multiple queries.
 
 **Snooze PRs** to hide them temporarily. Press `s` to snooze for a custom duration or indefinitely. Snoozed PRs live in a separate tab and don't clutter your main list.
 
-**Score breakdown** shows exactly how a PR's score was calculated. See which factors contributed most. Press `d` on any PR to open the detail view.
+**Score breakdown** shows exactly how a PR's score was calculated. See which factors contributed most. Press `b` on any PR to open the detail view.
 
 **ETag-based HTTP caching** reduces GitHub API calls. Auto-refresh only fetches if data changed on the server. Manual refresh bypasses in-memory cache.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,7 +127,7 @@ labels:
 
 A PR with both "urgent" and "critical" labels gets both effects: score + 10, then x2.
 
-Each matching label appears as a separate entry in the score breakdown detail view (press `d`).
+Each matching label appears as a separate entry in the score breakdown detail view (press `b`).
 
 ### Previously Reviewed
 


### PR DESCRIPTION
## Summary

- Updates 3 remaining references to the old `d` keybind in documentation:
  - `README.md` (2 occurrences)
  - `docs/configuration.md` (1 occurrence)

Follows up on #10 and #12.

## Test plan

- [x] Grep confirms no remaining `d`-for-score-breakdown references in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)