### PR TITLE
fix(ci): disable semver-check for binary crate

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,7 @@
 [workspace]
 git_tag_name = "v{{ version }}"
 git_release_type = "auto"
+semver_check = false
 pr_labels = ["release"]
 
 [changelog]


### PR DESCRIPTION
## Summary
- Disables `cargo-semver-checks` in release-plz config by setting `semver_check = false`
- `cargo-semver-checks` scans public API for breaking changes, which is only useful for library crates
- `pr-bro` is a binary application with no downstream Rust consumers, so this check provides no value

## Test plan
- [ ] Verify release-plz CI run no longer logs "Checking API compatibility with cargo-semver-checks..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)