### PR TITLE
fix(ci): use PAT for release-plz to trigger CI on release PRs

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Run release-plz
         uses: release-plz/action@v0.5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}


### PR DESCRIPTION
## Summary
- Changes release-plz workflow to use `RELEASE_PLZ_TOKEN` secret instead of `GITHUB_TOKEN`
- Fixes CI checks showing "Waiting for status to be reported" on release-plz PRs
- Root cause: GitHub prevents `GITHUB_TOKEN`-triggered workflows from triggering other workflows

## Setup required
Before merging, create a **fine-grained PAT** and add it as a repository secret named `RELEASE_PLZ_TOKEN`:

1. Go to https://github.com/settings/personal-access-tokens/new
2. Set **Repository access** → Only select repositories → `toniperic/pr-bro`
3. Under **Repository permissions**, grant:
   - **Contents**: Read and write (push branches, create tags/releases)
   - **Pull requests**: Read and write (create/update release PRs)
4. Create the token
5. Go to repo Settings → Secrets and variables → Actions → New repository secret
6. Name: `RELEASE_PLZ_TOKEN`, Value: the token you just created

## Test plan
- [ ] Add `RELEASE_PLZ_TOKEN` secret to the repo
- [ ] Merge this PR, then push another change to master
- [ ] Verify the next release-plz PR has CI checks running (not stuck at "Waiting")

🤖 Generated with [Claude Code](https://claude.com/claude-code)