### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/toniperic/pr-bro/compare/v0.2.0...v0.2.1) - 2026-02-04
+
+### Added
+
+- change score breakdown keybind from 'd' to 'b' ([#10](https://github.com/toniperic/pr-bro/pull/10))
+
+### Fixed
+
+- *(ci)* use PAT for release-plz to trigger CI on release PRs ([#15](https://github.com/toniperic/pr-bro/pull/15))
+- *(ci)* disable semver-check for binary crate ([#14](https://github.com/toniperic/pr-bro/pull/14))
+- update docs references from 'd' to 'b' for score breakdown
+- update footer hint from 'd' to 'b' for score breakdown ([#12](https://github.com/toniperic/pr-bro/pull/12))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr-bro"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Know which PR to review next. Ranks pull requests by weighted scoring."
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `pr-bro`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/toniperic/pr-bro/compare/v0.2.0...v0.2.1) - 2026-02-04

### Added

- change score breakdown keybind from 'd' to 'b' ([#10](https://github.com/toniperic/pr-bro/pull/10))

### Fixed

- *(ci)* use PAT for release-plz to trigger CI on release PRs ([#15](https://github.com/toniperic/pr-bro/pull/15))
- *(ci)* disable semver-check for binary crate ([#14](https://github.com/toniperic/pr-bro/pull/14))
- update docs references from 'd' to 'b' for score breakdown
- update footer hint from 'd' to 'b' for score breakdown ([#12](https://github.com/toniperic/pr-bro/pull/12))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).