### PR TITLE
ci: update ARM macOS runner from macos-14 to macos-15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
           - target: aarch64-apple-darwin
-            os: macos-14
+            os: macos-15
             use-cross: false
           - target: x86_64-apple-darwin
             os: macos-15-intel


### PR DESCRIPTION
## Summary
- Updates the ARM (`aarch64-apple-darwin`) macOS runner from `macos-14` to `macos-15`
- Standardizes both macOS build targets on macOS 15 runners

## Test plan
- [ ] Verify next release build succeeds for `aarch64-apple-darwin` on `macos-15`

🤖 Generated with [Claude Code](https://claude.com/claude-code)