### PR TITLE
ci: enable trusted publishing for crates.io

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   pull-requests: write
   contents: write
+  id-token: write
 
 jobs:
   release-plz:


### PR DESCRIPTION
## Summary
- Adds `id-token: write` permission to the release-plz workflow
- Enables OIDC-based trusted publishing to crates.io (no API token secret needed)
- Fixes the `failed to release package: no token found` error on release

## Setup required
Before merging, configure trusted publishing on crates.io:

1. Go to https://crates.io/settings/tokens/new-trusted-publisher (you may need to first publish the crate manually once, or claim it)
2. **If the crate already exists on crates.io:** Go to https://crates.io/crates/pr-bro/settings → "Add a trusted publisher"
3. Fill in:
   - **GitHub repository owner:** `toniperic`
   - **GitHub repository name:** `pr-bro`
   - **Workflow filename:** `release-plz.yml`
   - **Environment:** _(leave blank)_
4. Save

## Test plan
- [ ] Configure trusted publisher on crates.io
- [ ] Merge this PR, then merge a release-plz PR
- [ ] Verify `release-plz release` step publishes successfully to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)