### PR TITLE
ci: pass CARGO_REGISTRY_TOKEN for crates.io publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,3 +25,4 @@ jobs:
         uses: release-plz/action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- Passes `CARGO_REGISTRY_TOKEN` secret to the release-plz step
- Fixes crates.io publishing failure: trusted publishing OIDC is in the workflow but no trusted publisher is configured on crates.io yet, and the token fallback wasn't being passed through
- Once trusted publishing is configured on crates.io, the OIDC flow will take priority and the token becomes a redundant fallback

## Test plan
- [ ] Merge this PR, then re-run the failed release-plz workflow (or trigger via next push to master)
- [ ] Verify `pr-bro` v0.2.1 is published to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)