### PR TITLE
chore: bump minor version on feat commits in pre-stable releases

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,6 +2,7 @@
 git_tag_name = "v{{ version }}"
 git_release_type = "auto"
 semver_check = false
+features_always_increment_minor = true
 pr_labels = ["release"]
 
 [changelog]


### PR DESCRIPTION
## Summary

- Adds `features_always_increment_minor = true` to `release-plz.toml`
- With this setting, `feat` conventional commits will bump `0.2.x` → `0.3.0` instead of `0.2.x` → `0.2.(x+1)`
- Without it, release-plz treats `feat` the same as `fix` for pre-1.0 versions (patch bump only)

**Note:** The release-plz docs warn this violates Cargo SemVer conventions where `0.x` → `0.(x+1)` is reserved for breaking changes. This is an intentional choice for this project.

## Test plan

- [ ] Verify release-plz CI workflow still runs successfully
- [ ] Next `feat` commit on master should produce a `0.3.0` release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)