### PR TITLE
refactor(tui): rename "detail" nav hint to "breakdown"

### DIFF
--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -320,7 +320,7 @@ fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
             View::Active => vec![
                 ("j", "/", "k", ":nav "),
                 ("Enter", "", "", ":open "),
-                ("b", "", "", ":detail "),
+                ("b", "", "", ":breakdown "),
                 ("s", "", "", ":snooze "),
                 ("r", "", "", ":refresh "),
                 ("Tab", "", "", ":snoozed "),
@@ -330,7 +330,7 @@ fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
             View::Snoozed => vec![
                 ("j", "/", "k", ":nav "),
                 ("Enter", "", "", ":open "),
-                ("b", "", "", ":detail "),
+                ("b", "", "", ":breakdown "),
                 ("s", "", "", ":resnooze "),
                 ("u", "", "", ":unsnooze "),
                 ("r", "", "", ":refresh "),


### PR DESCRIPTION
## Summary

- Renames the `b` key navigation hint from `:detail` to `:breakdown` in both Active and Snoozed views
- The `b` key opens the score breakdown popup, so "breakdown" better describes what it does

## Test plan

- [ ] Run the TUI and verify the bottom navigation shows `:breakdown` next to `b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)