### PR TITLE
ci: pin cross to v0.2.5 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install cross
         if: matrix.use-cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
 
       - name: Build release binary
         run: |


### PR DESCRIPTION
## Summary
- Pins `cross` installation in the release workflow to `v0.2.5` (current latest) instead of installing from git HEAD
- Prevents surprise breakage if cross-rs ships a breaking change on their main branch

## Test plan
- [ ] Verify release workflow still builds the `aarch64-unknown-linux-gnu` target successfully (uses cross)

🤖 Generated with [Claude Code](https://claude.com/claude-code)