### PR TITLE
ci: remove redundant release build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+      - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
 
   clippy:
@@ -42,12 +43,3 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-features
-
-  build:
-    name: Build Release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo build --release --all-features


### PR DESCRIPTION
## Summary
- Removes the `Build Release` job from CI which compiled in release mode without producing artifacts
- The `test` and `clippy` jobs already compile the project, and actual release builds happen in `release.yml`
- Saves ~2-3 min of CI time per push/PR

## Test plan
- [ ] Verify remaining CI jobs (fmt, clippy, test) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)