### PR TITLE
chore: add Dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with daily checks for:
  - **Cargo** dependencies
  - **GitHub Actions** versions
- Commit messages prefixed with `chore(deps)` to match project conventions

## Test plan
- [ ] Verify Dependabot starts creating PRs after merge
- [ ] Confirm PR titles use `chore(deps)` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)