### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/toniperic/pr-bro/compare/v0.2.2...v0.2.3) - 2026-02-05
+
+### Other
+
+- *(deps)* bump actions/checkout from 4 to 6
+- *(deps)* bump jsonwebtoken from 10.2.0 to 10.3.0
+- add Dependabot for dependency updates
+- *(deps)* bump bytes from 1.11.0 to 1.11.1
+- track Cargo.lock for reproducible builds
+- simplify README installation sections
+- pin cross to v0.2.5 in release workflow
+- remove redundant release build job
+- *(quick-019)* simplify README quick start and remove Configuration section
+- *(tui)* rename "detail" nav hint to "breakdown"
+
 ## [0.2.2](https://github.com/toniperic/pr-bro/compare/v0.2.1...v0.2.2) - 2026-02-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "pr-bro"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "atomic-write-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr-bro"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "Know which PR to review next. Ranks pull requests by weighted scoring."
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `pr-bro`: 0.2.2 -> 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/toniperic/pr-bro/compare/v0.2.2...v0.2.3) - 2026-02-05

### Other

- *(deps)* bump actions/checkout from 4 to 6
- *(deps)* bump jsonwebtoken from 10.2.0 to 10.3.0
- add Dependabot for dependency updates
- *(deps)* bump bytes from 1.11.0 to 1.11.1
- track Cargo.lock for reproducible builds
- simplify README installation sections
- pin cross to v0.2.5 in release workflow
- remove redundant release build job
- *(quick-019)* simplify README quick start and remove Configuration section
- *(tui)* rename "detail" nav hint to "breakdown"
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).