### PR TITLE
docs: add Asciinema demo link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CI](https://github.com/toniperic/pr-bro/actions/workflows/ci.yml/badge.svg)](https://github.com/toniperic/pr-bro/actions/workflows/ci.yml) [![Crates.io](https://img.shields.io/crates/v/pr-bro.svg)](https://crates.io/crates/pr-bro) [![Downloads](https://img.shields.io/crates/d/pr-bro.svg)](https://crates.io/crates/pr-bro) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+[![Demo](https://asciinema.org/a/780716.svg)](https://asciinema.org/a/780716)
+
 Know which PR to review next. PR Bro ranks pull requests by weighted scoring across your GitHub queries, so you always start with the most important review.
 
 ## Requirements


### PR DESCRIPTION
## Summary
- Adds clickable Asciinema demo badge after the shields.io badges
- Links to https://asciinema.org/a/lKUveNxV2h96dC6M so users can see PR Bro in action before installing

## Test plan
- [ ] Verify badge renders correctly on GitHub
- [ ] Verify link opens the Asciinema recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)