### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/toniperic/pr-bro/compare/v0.2.3...v0.2.4) - 2026-02-05
+
+### Fixed
+
+- update rpassword API call for v7.x compatibility
+
+### Other
+
+- *(quick-025)* filter release-plz to meaningful commit types
+- run cargo fmt
+- *(deps)* bump rpassword from 5.0.1 to 7.4.0
+- add Asciinema demo link to README
+
 ## [0.2.3](https://github.com/toniperic/pr-bro/compare/v0.2.2...v0.2.3) - 2026-02-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "pr-bro"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "atomic-write-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr-bro"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = "Know which PR to review next. Ranks pull requests by weighted scoring."
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `pr-bro`: 0.2.3 -> 0.2.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.4](https://github.com/toniperic/pr-bro/compare/v0.2.3...v0.2.4) - 2026-02-05

### Fixed

- update rpassword API call for v7.x compatibility

### Other

- *(quick-025)* filter release-plz to meaningful commit types
- run cargo fmt
- *(deps)* bump rpassword from 5.0.1 to 7.4.0
- add Asciinema demo link to README
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).