### PR TITLE
chore: filter release-plz to meaningful commit types

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,6 +4,7 @@ git_release_type = "auto"
 semver_check = false
 features_always_increment_minor = true
 pr_labels = ["release"]
+release_commits = "^(feat|fix|perf|refactor)[(:]"
 
 [changelog]
 protect_breaking_commits = true


### PR DESCRIPTION
## Summary

Configures release-plz to only trigger releases for meaningful commit types.

## Changes

- Added `release_commits` filter to `[workspace]` section in `release-plz.toml`
- Filter regex: `^(feat|fix|perf|refactor)[(:]`

## Behavior

**Commit types that WILL trigger releases:**
- `feat`: New features
- `fix`: Bug fixes
- `perf`: Performance improvements
- `refactor`: Code refactoring

**Commit types that will NOT trigger releases:**
- `ci`: CI/CD changes
- `docs`: Documentation updates
- `chore`: Maintenance tasks
- `build`: Build system changes
- `style`: Code style/formatting
- `test`: Test updates

## Why

Prevents unnecessary version bumps and releases for non-functional changes like documentation updates, CI configuration, or code formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)