### PR TITLE
fix: lighten muted text color for better readability

### DIFF
--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -41,7 +41,7 @@ pub const TAB_ACTIVE: Style = Style::new().reversed();
 pub const ROW_SELECTED: Style = Style::new().reversed();
 
 // General colors
-pub const MUTED: Color = Color::DarkGray; // For secondary text
+pub const MUTED: Color = Color::Gray; // For secondary text (ANSI 7, terminal-themed)
 
 // Title bar colors
 pub const TITLE_COLOR: Color = Color::Cyan; // Accent color for app name

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -737,7 +737,7 @@ fn render_score_breakdown_popup(frame: &mut Frame, app: &App) {
                 ),
                 Span::styled(
                     format!("{:.1}", factor.before),
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme::MUTED),
                 ),
                 Span::raw(" -> "),
                 Span::styled(
@@ -749,7 +749,7 @@ fn render_score_breakdown_popup(frame: &mut Frame, app: &App) {
             // Line 2: indented description
             lines.push(Line::from(Span::styled(
                 format!("  {}", factor.description),
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme::MUTED),
             )));
         }
     }


### PR DESCRIPTION
## Summary
- Change `MUTED` color from `Color::DarkGray` (ANSI 8) to `Color::Gray` (ANSI 7) for lighter secondary text, while remaining terminal-theme-aware
- Consolidate direct `Color::DarkGray` usage in score breakdown modal to use `theme::MUTED` for consistency

## Test plan
- [ ] Open score breakdown modal and verify muted text (factor descriptions, "before" values, PR reference, close hint) is visibly lighter
- [ ] Verify muted text remains readable across light and dark terminal themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)