### PR TITLE
perf: auto-evict stale cache entries on startup

### DIFF
--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -3,7 +3,7 @@ pub mod client;
 pub mod search;
 pub mod types;
 
-pub use cache::{clear_cache, get_cache_path, CacheConfig, DiskCache};
+pub use cache::{clear_cache, evict_stale_entries, get_cache_path, CacheConfig, DiskCache};
 pub use client::create_client;
 pub use search::{search_and_enrich_prs, search_prs};
 pub use types::PullRequest;

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,10 @@ async fn main() {
     // Evict stale cache entries (older than 7 days)
     let evicted = pr_bro::github::evict_stale_entries();
     if cli.verbose && evicted > 0 {
-        eprintln!("Evicted {} stale cache entries (older than 7 days)", evicted);
+        eprintln!(
+            "Evicted {} stale cache entries (older than 7 days)",
+            evicted
+        );
     }
 
     // Handle init subcommand (before config load)

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,12 @@ async fn main() {
         }
     }
 
+    // Evict stale cache entries (older than 7 days)
+    let evicted = pr_bro::github::evict_stale_entries();
+    if cli.verbose && evicted > 0 {
+        eprintln!("Evicted {} stale cache entries (older than 7 days)", evicted);
+    }
+
     // Handle init subcommand (before config load)
     if matches!(command, Commands::Init) {
         let config_path = config_path_str.map(PathBuf::from);


### PR DESCRIPTION
## Summary
- Adds `evict_stale_entries()` to automatically remove cacache entries older than 7 days on every startup
- Runs after `--clear-cache` early exit, before config/credential loading
- Eviction count logged only in `--verbose` mode (silent otherwise)

## Test plan
- [ ] Run `cargo run -- --verbose list` and verify eviction log appears if stale entries exist
- [ ] Run `cargo run -- list` and verify no eviction output in normal mode
- [ ] Verify `cargo test` passes
- [ ] Verify `cargo clippy` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)