### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/toniperic/pr-bro/compare/v0.3.1...v0.3.2) - 2026-02-08
+
+### Fixed
+
+- suppress enrichment warnings that corrupt TUI display ([#57](https://github.com/toniperic/pr-bro/pull/57))
+
 ## [0.3.1](https://github.com/toniperic/pr-bro/compare/v0.3.0...v0.3.1) - 2026-02-08
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "pr-bro"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "atomic-write-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr-bro"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "Know which PR to review next. Ranks pull requests by weighted scoring."
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `pr-bro`: 0.3.1 -> 0.3.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/toniperic/pr-bro/compare/v0.3.1...v0.3.2) - 2026-02-08

### Fixed

- suppress enrichment warnings that corrupt TUI display ([#57](https://github.com/toniperic/pr-bro/pull/57))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).