### PR TITLE
fix: buffer stderr during TUI mode to prevent display corruption

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,3 +1,4 @@
+use crate::buffered_eprintln;
 use crate::config::Config;
 use crate::github::cache::CacheConfig;
 use crate::github::types::PullRequest;
@@ -47,7 +48,7 @@ pub async fn fetch_and_score_prs(
         } else {
             "disabled (--no-cache)"
         };
-        eprintln!("Cache: {}", cache_status);
+        buffered_eprintln!("Cache: {}", cache_status);
     }
 
     // Resolve global scoring config once (fallback for queries without per-query scoring)
@@ -73,7 +74,6 @@ pub async fn fetch_and_score_prs(
                 &query,
                 auth_username_clone.as_deref(),
                 exclude_patterns,
-                verbose,
             )
             .await;
             (query_name, query, query_index, result)
@@ -84,7 +84,7 @@ pub async fn fetch_and_score_prs(
         match result {
             Ok(prs) => {
                 if verbose {
-                    eprintln!(
+                    buffered_eprintln!(
                         "  Found {} PRs for {}",
                         prs.len(),
                         name.as_deref().unwrap_or(&query)
@@ -99,13 +99,11 @@ pub async fn fetch_and_score_prs(
                 if e.downcast_ref::<AuthError>().is_some() {
                     return Err(e);
                 }
-                if verbose {
-                    eprintln!(
-                        "Query failed: {} - {}",
-                        name.as_deref().unwrap_or(&query),
-                        e
-                    );
-                }
+                buffered_eprintln!(
+                    "Query failed: {} - {}",
+                    name.as_deref().unwrap_or(&query),
+                    e
+                );
             }
         }
     }
@@ -132,7 +130,7 @@ pub async fn fetch_and_score_prs(
         .collect();
 
     if verbose {
-        eprintln!("After deduplication: {} unique PRs", unique_prs.len());
+        buffered_eprintln!("After deduplication: {} unique PRs", unique_prs.len());
     }
 
     // Split into active and snoozed
@@ -140,7 +138,7 @@ pub async fn fetch_and_score_prs(
     let snoozed_prs = filter_snoozed_prs(unique_prs, snooze_state);
 
     if verbose {
-        eprintln!(
+        buffered_eprintln!(
             "After filter: {} active, {} snoozed",
             active_prs.len(),
             snoozed_prs.len()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,6 @@ pub mod github;
 pub mod output;
 pub mod scoring;
 pub mod snooze;
+pub mod stderr_buffer;
 pub mod tui;
 pub mod version_check;

--- a/src/stderr_buffer.rs
+++ b/src/stderr_buffer.rs
@@ -1,0 +1,35 @@
+use std::sync::Mutex;
+
+static BUFFER: Mutex<Option<Vec<String>>> = Mutex::new(None);
+
+/// Activate buffering. While active, `warn!()` calls store messages
+/// instead of printing to stderr.
+pub fn activate() {
+    *BUFFER.lock().unwrap() = Some(Vec::new());
+}
+
+/// Deactivate buffering and return all collected messages.
+pub fn drain() -> Vec<String> {
+    BUFFER.lock().unwrap().take().unwrap_or_default()
+}
+
+/// Write a warning message. If buffering is active the message is stored;
+/// otherwise it is printed to stderr immediately.
+pub fn warn(msg: String) {
+    let mut guard = BUFFER.lock().unwrap();
+    if let Some(buf) = guard.as_mut() {
+        buf.push(msg);
+    } else {
+        drop(guard);
+        eprintln!("{}", msg);
+    }
+}
+
+/// Convenience macro that works like `eprintln!` but routes through the
+/// stderr buffer when it is active.
+#[macro_export]
+macro_rules! buffered_eprintln {
+    ($($arg:tt)*) => {
+        $crate::stderr_buffer::warn(format!($($arg)*))
+    };
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -11,6 +11,9 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use event::{Event, EventHandler};
 
 pub async fn run_tui(mut app: App, mut client: octocrab::Octocrab) -> anyhow::Result<()> {
+    // Buffer stderr while TUI is active to prevent output corrupting the display
+    crate::stderr_buffer::activate();
+
     // Init terminal (sets up panic hooks automatically)
     let mut terminal = ratatui::init();
 
@@ -214,6 +217,12 @@ pub async fn run_tui(mut app: App, mut client: octocrab::Octocrab) -> anyhow::Re
 
     // Restore terminal
     ratatui::restore();
+
+    // Flush buffered stderr messages now that the terminal is restored
+    for msg in crate::stderr_buffer::drain() {
+        eprintln!("{}", msg);
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Replaces PR #57 with a better approach — instead of gating warnings on `--verbose`, all `eprintln!` output from background tasks is now **buffered** while the TUI is active
- Adds a `stderr_buffer` module with a global thread-safe message buffer activated before `ratatui::init()` and drained after `ratatui::restore()`
- After quitting the TUI (q/Ctrl+C), buffered messages appear in the terminal alongside other startup output (config loaded, authenticated as, etc.)
- Works correctly regardless of `--verbose` flag — both warnings and verbose status messages are buffered

## Test plan
- [ ] Run `pr-bro` in TUI mode — verify no stderr output corrupts the display during enrichment failures or verbose logging
- [ ] Quit TUI with `q` — verify buffered warnings/status messages appear in terminal output after exit
- [ ] Run `pr-bro --verbose` in TUI mode — verify verbose messages also appear only after exit
- [ ] Run `pr-bro --non-interactive` — verify warnings still print immediately to stderr (no buffering in CLI mode)
- [ ] `cargo test` passes (130/130)

Supersedes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)