### PR TITLE
chore: default query to review-requested:@me review:required is:open

### DIFF
--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -274,12 +274,19 @@ pub fn run_init_wizard(default_path: Option<PathBuf>) -> Result<()> {
         query_count += 1;
         let name = format!("Query {}", query_count);
 
-        let query = loop {
-            let q = prompt("GitHub search query: ")?;
-            if !q.is_empty() {
-                break q;
+        let query = if query_count == 1 {
+            prompt_with_default(
+                "GitHub search query",
+                "review-requested:@me review:required is:open",
+            )?
+        } else {
+            loop {
+                let q = prompt("GitHub search query: ")?;
+                if !q.is_empty() {
+                    break q;
+                }
+                println!("  Search query is required.");
             }
-            println!("  Search query is required.");
         };
 
         queries.push(QueryConfig {


### PR DESCRIPTION
## Summary
- Sets `review-requested:@me review:required is:open` as the default first query when initializing config
- Users can accept the default by pressing Enter, or type a custom query to override

## Test plan
- [ ] Run `pr-bro init` and verify the default query is shown in brackets
- [ ] Press Enter to accept the default and verify it's saved correctly
- [ ] Type a custom query and verify the default is overridden

🤖 Generated with [Claude Code](https://claude.com/claude-code)