### PR TITLE
fix: add inner padding to score breakdown modal

### DIFF
--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -7,6 +7,7 @@ use ratatui::widgets::{
     Block, Cell, Clear, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table,
     Tabs,
 };
+use ratatui::layout::Margin;
 
 pub fn draw(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
@@ -665,7 +666,7 @@ fn render_score_breakdown_popup(frame: &mut Frame, app: &App) {
     let content_height = 4 + factor_lines + 3;
     let popup_height = (content_height as u16).min(frame.area().height.saturating_sub(2));
 
-    let popup_area = centered_rect_fixed(55, popup_height, frame.area());
+    let popup_area = centered_rect_fixed(57, popup_height + 2, frame.area());
 
     // Clear the background
     frame.render_widget(Clear, popup_area);
@@ -680,6 +681,7 @@ fn render_score_breakdown_popup(frame: &mut Frame, app: &App) {
 
     // Get inner area (inside the border)
     let inner = block.inner(popup_area);
+    let inner = inner.inner(Margin { horizontal: 1, vertical: 1 });
 
     // Build content lines
     let mut lines = Vec::new();

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2,12 +2,12 @@ use crate::tui::app::{App, InputMode, View};
 use crate::tui::theme;
 use crate::version_check::VersionStatus;
 use chrono::{Datelike, Local};
+use ratatui::layout::Margin;
 use ratatui::prelude::*;
 use ratatui::widgets::{
     Block, Cell, Clear, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table,
     Tabs,
 };
-use ratatui::layout::Margin;
 
 pub fn draw(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
@@ -681,7 +681,10 @@ fn render_score_breakdown_popup(frame: &mut Frame, app: &App) {
 
     // Get inner area (inside the border)
     let inner = block.inner(popup_area);
-    let inner = inner.inner(Margin { horizontal: 1, vertical: 1 });
+    let inner = inner.inner(Margin {
+        horizontal: 1,
+        vertical: 1,
+    });
 
     // Build content lines
     let mut lines = Vec::new();


### PR DESCRIPTION
## Summary
- Adds 1-cell horizontal and 1-cell vertical inner padding to the score breakdown modal
- Increases popup dimensions by +2 width and +2 height to compensate, keeping effective content area the same
- Content no longer renders flush against the border

## Test plan
- [x] `cargo build` compiles
- [x] Visual verification — modal content has breathing room from border on all sides
- [x] All content remains visible and not clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)