### PR TITLE
feat: add light mode configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,10 @@ Configuration file location: `~/.config/pr-bro/config.yaml`
 # Auto-refresh interval in seconds (default: 300 = 5 minutes)
 auto_refresh_interval: 300
 
+# TUI theme (default: dark)
+# Options: dark, light
+theme: dark
+
 # Global scoring configuration (applies to all queries unless overridden)
 scoring:
   base_score: 100
@@ -44,6 +48,25 @@ queries:
       age: "x1.5 per 1d"  # Gets a x1.5 boost per day of age
       approvals: "+5 per 1"
 ```
+
+## Theme
+
+Optional. Controls the color scheme of the TUI interface.
+
+**Options:**
+- `dark` (default) — Dark theme optimized for terminals with dark backgrounds
+- `light` — Light theme optimized for terminals with light backgrounds
+
+Example:
+
+```yaml
+theme: light
+```
+
+The light theme adjusts colors for better readability on light terminal backgrounds:
+- Darker text colors for better contrast
+- Lighter backgrounds for UI elements
+- Adjusted accent colors for better visibility
 
 ## Scoring Factors
 

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -331,6 +331,7 @@ pub fn run_init_wizard(default_path: Option<PathBuf>) -> Result<()> {
         scoring: Some(scoring),
         queries,
         auto_refresh_interval: 300,
+        theme: crate::tui::theme::ThemeVariant::default(),
     };
 
     let yaml = serde_saphyr::to_string(&config)

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::scoring::ScoringConfig;
+use crate::tui::theme::ThemeVariant;
 
 fn default_refresh_interval() -> u64 {
     300
@@ -18,6 +19,10 @@ pub struct Config {
     /// Auto-refresh interval in seconds (defaults to 300 = 5 minutes)
     #[serde(default = "default_refresh_interval")]
     pub auto_refresh_interval: u64,
+
+    /// TUI theme (dark or light, defaults to dark)
+    #[serde(default)]
+    pub theme: ThemeVariant,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3,6 +3,7 @@ use crate::github::cache::{CacheConfig, DiskCache};
 use crate::github::types::PullRequest;
 use crate::scoring::ScoreResult;
 use crate::snooze::SnoozeState;
+use crate::tui::theme::Theme;
 use crate::version_check::VersionStatus;
 use chrono::{DateTime, Utc};
 use std::collections::VecDeque;
@@ -69,6 +70,7 @@ pub struct App {
     pub auth_username: Option<String>,
     pub version_status: VersionStatus,
     pub no_version_check: bool,
+    pub theme: Theme,
 }
 
 impl App {
@@ -89,6 +91,8 @@ impl App {
         if !active_prs.is_empty() {
             table_state.select(Some(0));
         }
+
+        let theme = Theme::new(config.theme);
 
         Self {
             active_prs,
@@ -115,6 +119,7 @@ impl App {
             auth_username,
             version_status: VersionStatus::Unknown,
             no_version_check,
+            theme,
         }
     }
 
@@ -131,6 +136,8 @@ impl App {
         auth_username: Option<String>,
         no_version_check: bool,
     ) -> Self {
+        let theme = Theme::new(config.theme);
+
         Self {
             active_prs: Vec::new(),
             snoozed_prs: Vec::new(),
@@ -156,6 +163,7 @@ impl App {
             auth_username,
             version_status: VersionStatus::Unknown,
             no_version_check,
+            theme,
         }
     }
 

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -1,74 +1,265 @@
 //! Centralized theme module for TUI color constants and styles
 
 use ratatui::prelude::*;
+use serde::{Deserialize, Serialize};
 
-// Score-based colors (based on relative score percentage 0-100%)
-pub const SCORE_HIGH: Color = Color::Red; // >= 70% of max — most urgent
-pub const SCORE_MID: Color = Color::Yellow; // >= 40% of max
-pub const SCORE_LOW: Color = Color::Green; // < 40% of max — less urgent
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ThemeVariant {
+    Dark,
+    Light,
+}
 
-/// Returns the appropriate color for a score based on its percentage of max score
-pub fn score_color(score: f64, max_score: f64) -> Color {
-    let percentage = if max_score > 0.0 {
-        (score / max_score) * 100.0
-    } else {
-        0.0
-    };
-
-    if percentage >= 70.0 {
-        SCORE_HIGH
-    } else if percentage >= 40.0 {
-        SCORE_MID
-    } else {
-        SCORE_LOW
+impl Default for ThemeVariant {
+    fn default() -> Self {
+        Self::Dark
     }
 }
 
-// Score bar colors (same thresholds as score text)
-pub const BAR_FILLED_HIGH: Color = Color::Red;
-pub const BAR_FILLED_MID: Color = Color::Yellow;
-pub const BAR_FILLED_LOW: Color = Color::Green;
-pub const BAR_EMPTY: Color = Color::DarkGray;
+/// Theme holds all colors and styles for the TUI
+#[derive(Debug, Clone)]
+pub struct Theme {
+    variant: ThemeVariant,
+}
 
-// Table colors
-pub const ROW_ALT_BG: Color = Color::Indexed(235); // 256-color dark gray for alternating rows
-pub const INDEX_COLOR: Color = Color::DarkGray; // Index column color
+impl Theme {
+    pub fn new(variant: ThemeVariant) -> Self {
+        Self { variant }
+    }
 
-// Styles
-pub const TITLE_STYLE: Style = Style::new().bold();
-pub const HEADER_STYLE: Style = Style::new().bold();
-pub const TAB_ACTIVE: Style = Style::new().reversed();
-pub const ROW_SELECTED: Style = Style::new().reversed();
+    pub fn variant(&self) -> ThemeVariant {
+        self.variant
+    }
 
-// General colors
-pub const MUTED: Color = Color::Gray; // For secondary text (ANSI 7, terminal-themed)
+    // Score-based colors (based on relative score percentage 0-100%)
+    pub fn score_high(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Red,
+            ThemeVariant::Light => Color::Red,
+        }
+    }
 
-// Title bar colors
-pub const TITLE_COLOR: Color = Color::Cyan; // Accent color for app name
+    pub fn score_mid(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Yellow,
+            ThemeVariant::Light => Color::Rgb(180, 120, 0), // Darker yellow for light theme
+        }
+    }
 
-// Tab colors
-pub const TAB_ACTIVE_STYLE: Style = Style::new().fg(Color::Cyan).bold();
-pub const TAB_INACTIVE_STYLE: Style = Style::new().fg(Color::DarkGray);
+    pub fn score_low(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Green,
+            ThemeVariant::Light => Color::Green,
+        }
+    }
 
-// Status bar colors
-pub const STATUS_BAR_BG: Color = Color::Indexed(236); // Subtle dark background
-pub const STATUS_KEY_COLOR: Color = Color::Cyan; // Keyboard shortcut hints
-pub const FLASH_SUCCESS: Color = Color::Green; // Positive flash messages
-pub const FLASH_ERROR: Color = Color::Red; // Error flash messages
+    /// Returns the appropriate color for a score based on its percentage of max score
+    pub fn score_color(&self, score: f64, max_score: f64) -> Color {
+        let percentage = if max_score > 0.0 {
+            (score / max_score) * 100.0
+        } else {
+            0.0
+        };
 
-// Divider and separator colors
-pub const DIVIDER_COLOR: Color = Color::Indexed(238); // Subtle line color
+        if percentage >= 70.0 {
+            self.score_high()
+        } else if percentage >= 40.0 {
+            self.score_mid()
+        } else {
+            self.score_low()
+        }
+    }
 
-// Popup overlay colors
-pub const POPUP_BORDER: Color = Color::Cyan; // Accent color for popup borders
-pub const POPUP_TITLE: Style = Style::new().fg(Color::Cyan).bold();
-pub const POPUP_BG: Color = Color::Indexed(234); // Dark background for popup content
+    // Score bar colors (same thresholds as score text)
+    pub fn bar_filled_high(&self) -> Color {
+        self.score_high()
+    }
 
-// Scrollbar colors
-pub const SCROLLBAR_THUMB: Color = Color::Indexed(244); // Medium gray for scrollbar thumb
-pub const SCROLLBAR_TRACK: Color = Color::Indexed(236); // Dark gray for scrollbar track
+    pub fn bar_filled_mid(&self) -> Color {
+        self.score_mid()
+    }
 
-// Update banner colors
-pub const BANNER_BG: Color = Color::Rgb(50, 50, 120); // Dark blue-purple accent
-pub const BANNER_FG: Color = Color::White;
-pub const BANNER_KEY: Color = Color::Yellow; // Highlight for dismiss key hint
+    pub fn bar_filled_low(&self) -> Color {
+        self.score_low()
+    }
+
+    pub fn bar_empty(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::DarkGray,
+            ThemeVariant::Light => Color::Indexed(250), // Light gray
+        }
+    }
+
+    // Table colors
+    pub fn row_alt_bg(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Indexed(235), // Dark gray for alternating rows
+            ThemeVariant::Light => Color::Indexed(254), // Very light gray for alternating rows
+        }
+    }
+
+    pub fn index_color(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::DarkGray,
+            ThemeVariant::Light => Color::Gray,
+        }
+    }
+
+    // Styles
+    pub fn title_style(&self) -> Style {
+        Style::new().bold()
+    }
+
+    pub fn header_style(&self) -> Style {
+        Style::new().bold()
+    }
+
+    pub fn tab_active(&self) -> Style {
+        Style::new().reversed()
+    }
+
+    pub fn row_selected(&self) -> Style {
+        Style::new().reversed()
+    }
+
+    // General colors
+    pub fn muted(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Gray,
+            ThemeVariant::Light => Color::DarkGray,
+        }
+    }
+
+    pub fn text(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Reset, // Use terminal default
+            ThemeVariant::Light => Color::Black,
+        }
+    }
+
+    pub fn background(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Reset, // Use terminal default
+            ThemeVariant::Light => Color::White,
+        }
+    }
+
+    // Title bar colors
+    pub fn title_color(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Cyan,
+            ThemeVariant::Light => Color::Blue,
+        }
+    }
+
+    // Tab colors
+    pub fn tab_active_style(&self) -> Style {
+        match self.variant {
+            ThemeVariant::Dark => Style::new().fg(Color::Cyan).bold(),
+            ThemeVariant::Light => Style::new().fg(Color::Blue).bold(),
+        }
+    }
+
+    pub fn tab_inactive_style(&self) -> Style {
+        match self.variant {
+            ThemeVariant::Dark => Style::new().fg(Color::DarkGray),
+            ThemeVariant::Light => Style::new().fg(Color::Gray),
+        }
+    }
+
+    // Status bar colors
+    pub fn status_bar_bg(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Indexed(236), // Subtle dark background
+            ThemeVariant::Light => Color::Indexed(252), // Light gray background
+        }
+    }
+
+    pub fn status_key_color(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Cyan,
+            ThemeVariant::Light => Color::Blue,
+        }
+    }
+
+    pub fn flash_success(&self) -> Color {
+        Color::Green
+    }
+
+    pub fn flash_error(&self) -> Color {
+        Color::Red
+    }
+
+    // Divider and separator colors
+    pub fn divider_color(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Indexed(238), // Subtle line color
+            ThemeVariant::Light => Color::Indexed(248), // Light gray line
+        }
+    }
+
+    // Popup overlay colors
+    pub fn popup_border(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Cyan,
+            ThemeVariant::Light => Color::Blue,
+        }
+    }
+
+    pub fn popup_title(&self) -> Style {
+        match self.variant {
+            ThemeVariant::Dark => Style::new().fg(Color::Cyan).bold(),
+            ThemeVariant::Light => Style::new().fg(Color::Blue).bold(),
+        }
+    }
+
+    pub fn popup_bg(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Indexed(234), // Dark background for popup content
+            ThemeVariant::Light => Color::Indexed(255), // White background
+        }
+    }
+
+    // Scrollbar colors
+    pub fn scrollbar_thumb(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Indexed(244), // Medium gray
+            ThemeVariant::Light => Color::Indexed(240), // Darker gray for visibility
+        }
+    }
+
+    pub fn scrollbar_track(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Indexed(236), // Dark gray
+            ThemeVariant::Light => Color::Indexed(252), // Light gray
+        }
+    }
+
+    // Update banner colors
+    pub fn banner_bg(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Rgb(50, 50, 120), // Dark blue-purple accent
+            ThemeVariant::Light => Color::Rgb(200, 220, 255), // Light blue accent
+        }
+    }
+
+    pub fn banner_fg(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::White,
+            ThemeVariant::Light => Color::Black,
+        }
+    }
+
+    pub fn banner_key(&self) -> Color {
+        match self.variant {
+            ThemeVariant::Dark => Color::Yellow,
+            ThemeVariant::Light => Color::Rgb(180, 120, 0), // Darker yellow
+        }
+    }
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Self::new(ThemeVariant::default())
+    }
+}

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,5 +1,4 @@
 use crate::tui::app::{App, InputMode, View};
-use crate::tui::theme;
 use crate::version_check::VersionStatus;
 use chrono::{Datelike, Local};
 use ratatui::layout::Margin;
@@ -54,7 +53,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     // Render overlays based on input mode
     match app.input_mode {
         InputMode::SnoozeInput => render_snooze_popup(frame, app),
-        InputMode::Help => render_help_popup(frame),
+        InputMode::Help => render_help_popup(frame, app),
         InputMode::ScoreBreakdown => render_score_breakdown_popup(frame, app),
         InputMode::Normal => {}
     }
@@ -69,7 +68,7 @@ fn render_title(frame: &mut Frame, area: Rect, app: &App) {
     // Build title with rate limit on the right
     let mut spans = vec![Span::styled(
         "PR Bro",
-        Style::default().fg(theme::TITLE_COLOR).bold(),
+        Style::default().fg(app.theme.title_color()).bold(),
     )];
 
     // Add rate limit info on the right if available
@@ -83,7 +82,7 @@ fn render_title(frame: &mut Frame, area: Rect, app: &App) {
         spans.push(Span::raw(" ".repeat(padding_len)));
         spans.push(Span::styled(
             rate_limit_text,
-            Style::default().fg(theme::MUTED),
+            Style::default().fg(app.theme.muted()),
         ));
     }
 
@@ -97,14 +96,14 @@ fn render_update_banner(frame: &mut Frame, area: Rect, app: &App) {
         let banner_text = Line::from(vec![
             Span::styled(
                 format!("  Update available: v{} -> v{}  ", current, latest),
-                Style::default().fg(theme::BANNER_FG),
+                Style::default().fg(app.theme.banner_fg()),
             ),
             Span::raw("["),
-            Span::styled("x", Style::default().fg(theme::BANNER_KEY).bold()),
-            Span::styled(" to dismiss]", Style::default().fg(theme::BANNER_FG)),
+            Span::styled("x", Style::default().fg(app.theme.banner_key()).bold()),
+            Span::styled(" to dismiss]", Style::default().fg(app.theme.banner_fg())),
         ]);
 
-        let banner = Paragraph::new(banner_text).style(Style::default().bg(theme::BANNER_BG));
+        let banner = Paragraph::new(banner_text).style(Style::default().bg(app.theme.banner_bg()));
         frame.render_widget(banner, area);
     }
 }
@@ -118,8 +117,8 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
 
     let tabs = Tabs::new(titles)
         .select(selected)
-        .style(Style::default().fg(theme::MUTED))
-        .highlight_style(Style::default().fg(theme::TITLE_COLOR).bold().reversed())
+        .style(Style::default().fg(app.theme.muted()))
+        .highlight_style(Style::default().fg(app.theme.title_color()).bold().reversed())
         .divider(" | ")
         .padding("  ", "  ");
 
@@ -157,10 +156,10 @@ fn render_table(frame: &mut Frame, area: Rect, app: &mut App) {
                 .map(|(idx, (pr, score_result))| {
                     let index = format!("{}.", idx + 1);
                     let score_str = format_score(score_result.score, score_result.incomplete);
-                    let bar_line = score_bar(score_result.score, max_score, 8);
+                    let bar_line = score_bar(score_result.score, max_score, 8, &app.theme);
 
                     // Build score cell with colored text and bar
-                    let score_color = theme::score_color(score_result.score, max_score);
+                    let score_color = app.theme.score_color(score_result.score, max_score);
                     let mut score_spans = vec![Span::styled(
                         format!("{:>5} ", score_str),
                         Style::default().fg(score_color),
@@ -180,16 +179,16 @@ fn render_table(frame: &mut Frame, area: Rect, app: &mut App) {
 
                     // Alternating row background (odd rows get subtle background)
                     let row_style = if idx % 2 == 1 {
-                        Style::default().bg(theme::ROW_ALT_BG)
+                        Style::default().bg(app.theme.row_alt_bg())
                     } else {
                         Style::default()
                     };
 
                     Row::new(vec![
-                        Cell::from(index).style(Style::default().fg(theme::INDEX_COLOR)),
+                        Cell::from(index).style(Style::default().fg(app.theme.index_color())),
                         Cell::from(score_line),
                         Cell::from(title),
-                        Cell::from(duration).style(Style::default().fg(theme::MUTED)),
+                        Cell::from(duration).style(Style::default().fg(app.theme.muted())),
                         Cell::from(pr.short_ref()),
                     ])
                     .style(row_style)
@@ -215,10 +214,10 @@ fn render_table(frame: &mut Frame, area: Rect, app: &mut App) {
                 .map(|(idx, (pr, score_result))| {
                     let index = format!("{}.", idx + 1);
                     let score_str = format_score(score_result.score, score_result.incomplete);
-                    let bar_line = score_bar(score_result.score, max_score, 8);
+                    let bar_line = score_bar(score_result.score, max_score, 8, &app.theme);
 
                     // Build score cell with colored text and bar
-                    let score_color = theme::score_color(score_result.score, max_score);
+                    let score_color = app.theme.score_color(score_result.score, max_score);
                     let mut score_spans = vec![Span::styled(
                         format!("{:>5} ", score_str),
                         Style::default().fg(score_color),
@@ -230,13 +229,13 @@ fn render_table(frame: &mut Frame, area: Rect, app: &mut App) {
 
                     // Alternating row background (odd rows get subtle background)
                     let row_style = if idx % 2 == 1 {
-                        Style::default().bg(theme::ROW_ALT_BG)
+                        Style::default().bg(app.theme.row_alt_bg())
                     } else {
                         Style::default()
                     };
 
                     Row::new(vec![
-                        Cell::from(index).style(Style::default().fg(theme::INDEX_COLOR)),
+                        Cell::from(index).style(Style::default().fg(app.theme.index_color())),
                         Cell::from(score_line),
                         Cell::from(title),
                         Cell::from(pr.short_ref()),
@@ -260,10 +259,10 @@ fn render_table(frame: &mut Frame, area: Rect, app: &mut App) {
     let table = Table::new(rows, widths)
         .header(
             Row::new(header_cells)
-                .style(theme::HEADER_STYLE)
+                .style(app.theme.header_style())
                 .bottom_margin(1),
         )
-        .row_highlight_style(theme::ROW_SELECTED);
+        .row_highlight_style(app.theme.row_selected());
 
     frame.render_stateful_widget(table, area, &mut app.table_state);
 
@@ -271,8 +270,8 @@ fn render_table(frame: &mut Frame, area: Rect, app: &mut App) {
     let visible_rows = area.height.saturating_sub(2) as usize; // Subtract header and margin
     if pr_count > visible_rows {
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .thumb_style(Style::default().fg(theme::SCROLLBAR_THUMB))
-            .track_style(Style::default().fg(theme::SCROLLBAR_TRACK));
+            .thumb_style(Style::default().fg(app.theme.scrollbar_thumb()))
+            .track_style(Style::default().fg(app.theme.scrollbar_track()));
 
         let mut scrollbar_state = ScrollbarState::new(pr_count).position(selected_pos);
 
@@ -285,7 +284,7 @@ fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
         // Show flash message with color based on message type
         let msg_color =
             if msg.starts_with("Failed") || msg.starts_with("Error") || msg.contains("cancelled") {
-                theme::FLASH_ERROR
+                app.theme.flash_error()
             } else if msg.starts_with("Snoozed:")
                 || msg.starts_with("Unsnoozed:")
                 || msg.starts_with("Re-snoozed:")
@@ -293,7 +292,7 @@ fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
                 || msg.starts_with("Refreshed")
                 || msg.starts_with("Opened:")
             {
-                theme::FLASH_SUCCESS
+                app.theme.flash_success()
             } else {
                 Color::White // Default for unknown message types
             };
@@ -347,24 +346,24 @@ fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
             }
             hint_spans.push(Span::styled(
                 *key1,
-                Style::default().fg(theme::STATUS_KEY_COLOR),
+                Style::default().fg(app.theme.status_key_color()),
             ));
             if !sep.is_empty() {
                 hint_spans.push(Span::raw(*sep));
                 hint_spans.push(Span::styled(
                     *key2,
-                    Style::default().fg(theme::STATUS_KEY_COLOR),
+                    Style::default().fg(app.theme.status_key_color()),
                 ));
             }
             hint_spans.push(Span::raw(*label));
         }
 
         let mut spans = vec![
-            Span::styled(count, Style::default().fg(theme::MUTED)),
+            Span::styled(count, Style::default().fg(app.theme.muted())),
             Span::raw(" "),
-            Span::styled(view_mode, Style::default().fg(theme::MUTED)),
+            Span::styled(view_mode, Style::default().fg(app.theme.muted())),
             Span::raw(" "),
-            Span::styled(refresh_time, Style::default().fg(theme::MUTED)),
+            Span::styled(refresh_time, Style::default().fg(app.theme.muted())),
             Span::raw("  "),
         ];
         spans.extend(hint_spans);
@@ -372,7 +371,7 @@ fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
     };
 
     frame.render_widget(
-        Paragraph::new(text).style(Style::default().bg(theme::STATUS_BAR_BG)),
+        Paragraph::new(text).style(Style::default().bg(app.theme.status_bar_bg())),
         area,
     );
 }
@@ -396,7 +395,7 @@ fn format_score(score: f64, incomplete: bool) -> String {
     }
 }
 
-fn score_bar(score: f64, max_score: f64, width: usize) -> Line<'static> {
+fn score_bar(score: f64, max_score: f64, width: usize, theme: &crate::tui::theme::Theme) -> Line<'static> {
     let ratio = if max_score > 0.0 {
         (score / max_score).min(1.0)
     } else {
@@ -406,7 +405,7 @@ fn score_bar(score: f64, max_score: f64, width: usize) -> Line<'static> {
     let empty = width.saturating_sub(filled);
 
     // Get color based on score
-    let bar_color = theme::score_color(score, max_score);
+    let bar_color = theme.score_color(score, max_score);
 
     let mut spans = Vec::new();
     if filled > 0 {
@@ -418,7 +417,7 @@ fn score_bar(score: f64, max_score: f64, width: usize) -> Line<'static> {
     if empty > 0 {
         spans.push(Span::styled(
             "░".repeat(empty),
-            Style::default().fg(theme::BAR_EMPTY),
+            Style::default().fg(theme.bar_empty()),
         ));
     }
 
@@ -435,9 +434,9 @@ fn render_snooze_popup(frame: &mut Frame, app: &App) {
     // Render the popup border with accent color
     let block = Block::bordered()
         .title("Snooze Duration")
-        .border_style(Style::default().fg(theme::POPUP_BORDER))
-        .title_style(theme::POPUP_TITLE)
-        .style(Style::default().bg(theme::POPUP_BG));
+        .border_style(Style::default().fg(app.theme.popup_border()))
+        .title_style(app.theme.popup_title())
+        .style(Style::default().bg(app.theme.popup_bg()));
     frame.render_widget(block.clone(), popup_area);
 
     // Get inner area (inside the border)
@@ -474,13 +473,13 @@ fn render_snooze_popup(frame: &mut Frame, app: &App) {
     };
 
     let preview_color = match &parse_result {
-        None => theme::MUTED,
+        None => app.theme.muted(),
         Some(Ok(_)) => Color::Green,
         Some(Err(_)) => Color::Red,
     };
 
     let preview = Paragraph::new(Line::from(vec![
-        Span::styled("Duration: ", Style::default().fg(theme::MUTED)),
+        Span::styled("Duration: ", Style::default().fg(app.theme.muted())),
         Span::styled(preview_text, Style::default().fg(preview_color)),
     ]));
     frame.render_widget(preview, chunks[1]);
@@ -513,12 +512,12 @@ fn render_snooze_popup(frame: &mut Frame, app: &App) {
         }
         Some(Err(_)) => String::new(),
     };
-    let end_time = Paragraph::new(end_time_text).style(Style::default().fg(theme::MUTED));
+    let end_time = Paragraph::new(end_time_text).style(Style::default().fg(app.theme.muted()));
     frame.render_widget(end_time, chunks[2]);
 
     // Render help text
     let help =
-        Paragraph::new("Enter: confirm | Esc: cancel").style(Style::default().fg(theme::MUTED));
+        Paragraph::new("Enter: confirm | Esc: cancel").style(Style::default().fg(app.theme.muted()));
     frame.render_widget(help, chunks[3]);
 }
 
@@ -541,7 +540,7 @@ fn centered_rect_fixed(width: u16, height: u16, area: Rect) -> Rect {
 }
 
 /// Render the help overlay popup
-fn render_help_popup(frame: &mut Frame) {
+fn render_help_popup(frame: &mut Frame, app: &App) {
     let popup_area = centered_rect_fixed(50, 17, frame.area());
 
     // Clear the background
@@ -550,9 +549,9 @@ fn render_help_popup(frame: &mut Frame) {
     // Render the popup border with accent color
     let block = Block::bordered()
         .title(" Keyboard Shortcuts ")
-        .border_style(Style::default().fg(theme::POPUP_BORDER))
-        .title_style(theme::POPUP_TITLE)
-        .style(Style::default().bg(theme::POPUP_BG));
+        .border_style(Style::default().fg(app.theme.popup_border()))
+        .title_style(app.theme.popup_title())
+        .style(Style::default().bg(app.theme.popup_bg()));
     frame.render_widget(block.clone(), popup_area);
 
     // Get inner area (inside the border)
@@ -607,7 +606,7 @@ fn render_help_popup(frame: &mut Frame) {
         Line::from(""),
         Line::from(Span::styled(
             "Press any key to close",
-            Style::default().fg(theme::MUTED),
+            Style::default().fg(app.theme.muted()),
         )),
     ];
 
@@ -624,8 +623,8 @@ fn render_loading_overlay(frame: &mut Frame, app: &App) {
 
     // Render the popup border with accent color
     let block = Block::bordered()
-        .border_style(Style::default().fg(theme::POPUP_BORDER))
-        .style(Style::default().bg(theme::POPUP_BG));
+        .border_style(Style::default().fg(app.theme.popup_border()))
+        .style(Style::default().bg(app.theme.popup_bg()));
     frame.render_widget(block.clone(), popup_area);
 
     // Get inner area (inside the border)
@@ -674,9 +673,9 @@ fn render_score_breakdown_popup(frame: &mut Frame, app: &App) {
     // Render the popup border with accent color
     let block = Block::bordered()
         .title(" Score Breakdown ")
-        .border_style(Style::default().fg(theme::POPUP_BORDER))
-        .title_style(theme::POPUP_TITLE)
-        .style(Style::default().bg(theme::POPUP_BG));
+        .border_style(Style::default().fg(app.theme.popup_border()))
+        .title_style(app.theme.popup_title())
+        .style(Style::default().bg(app.theme.popup_bg()));
     frame.render_widget(block.clone(), popup_area);
 
     // Get inner area (inside the border)
@@ -692,7 +691,7 @@ fn render_score_breakdown_popup(frame: &mut Frame, app: &App) {
     // Line 1: PR reference in muted text
     lines.push(Line::from(Span::styled(
         pr.short_ref(),
-        Style::default().fg(theme::MUTED),
+        Style::default().fg(app.theme.muted()),
     )));
 
     // Line 2: PR title (truncate if needed)
@@ -721,7 +720,7 @@ fn render_score_breakdown_popup(frame: &mut Frame, app: &App) {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             "No scoring factors configured",
-            Style::default().fg(theme::MUTED),
+            Style::default().fg(app.theme.muted()),
         )));
     } else {
         for factor in &breakdown.factors {
@@ -742,7 +741,7 @@ fn render_score_breakdown_popup(frame: &mut Frame, app: &App) {
                 ),
                 Span::styled(
                     format!("{:.1}", factor.before),
-                    Style::default().fg(theme::MUTED),
+                    Style::default().fg(app.theme.muted()),
                 ),
                 Span::raw(" -> "),
                 Span::styled(
@@ -754,7 +753,7 @@ fn render_score_breakdown_popup(frame: &mut Frame, app: &App) {
             // Line 2: indented description
             lines.push(Line::from(Span::styled(
                 format!("  {}", factor.description),
-                Style::default().fg(theme::MUTED),
+                Style::default().fg(app.theme.muted()),
             )));
         }
     }
@@ -768,7 +767,7 @@ fn render_score_breakdown_popup(frame: &mut Frame, app: &App) {
         .iter()
         .map(|(_, sr)| sr.score)
         .fold(0.0_f64, f64::max);
-    let score_color = theme::score_color(score_result.score, max_score);
+    let score_color = app.theme.score_color(score_result.score, max_score);
 
     lines.push(Line::from(vec![
         Span::raw("Final score: "),
@@ -781,7 +780,7 @@ fn render_score_breakdown_popup(frame: &mut Frame, app: &App) {
     // Line N: Help text
     lines.push(Line::from(Span::styled(
         "Esc or d to close",
-        Style::default().fg(theme::MUTED),
+        Style::default().fg(app.theme.muted()),
     )));
 
     let paragraph = Paragraph::new(lines);


### PR DESCRIPTION
I use a light colorscheme for my terminal and I couldn't see the titles for the PRs that were not selected. I don't know much about rust so I asked Claude to implement a new configuration field `theme` to allow for a light themed version

With the dark version:
<img width="452" height="153" alt="image" src="https://github.com/user-attachments/assets/61d089a0-0d1f-4ceb-a0c2-c56ce32aa93c" />

Light version with the titles showing:
<img width="473" height="154" alt="image" src="https://github.com/user-attachments/assets/01052b8b-ac4e-4a08-b4d9-b39e5c920e84" />

Thanks for the tool!