### PR TITLE
refactor: replace theme constants with ThemeColors struct

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3,6 +3,7 @@ use crate::github::cache::{CacheConfig, DiskCache};
 use crate::github::types::PullRequest;
 use crate::scoring::ScoreResult;
 use crate::snooze::SnoozeState;
+use crate::tui::theme::ThemeColors;
 use crate::version_check::VersionStatus;
 use chrono::{DateTime, Utc};
 use std::collections::VecDeque;
@@ -69,6 +70,7 @@ pub struct App {
     pub auth_username: Option<String>,
     pub version_status: VersionStatus,
     pub no_version_check: bool,
+    pub theme_colors: ThemeColors,
 }
 
 impl App {
@@ -115,6 +117,7 @@ impl App {
             auth_username,
             version_status: VersionStatus::Unknown,
             no_version_check,
+            theme_colors: ThemeColors::dark(),
         }
     }
 
@@ -156,6 +159,7 @@ impl App {
             auth_username,
             version_status: VersionStatus::Unknown,
             no_version_check,
+            theme_colors: ThemeColors::dark(),
         }
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4,6 +4,7 @@ pub mod theme;
 pub mod ui;
 
 pub use app::App;
+pub use theme::ThemeColors;
 
 use std::time::Duration;
 

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -2,73 +2,113 @@
 
 use ratatui::prelude::*;
 
-// Score-based colors (based on relative score percentage 0-100%)
-pub const SCORE_HIGH: Color = Color::Red; // >= 70% of max — most urgent
-pub const SCORE_MID: Color = Color::Yellow; // >= 40% of max
-pub const SCORE_LOW: Color = Color::Green; // < 40% of max — less urgent
+/// Complete color palette for the TUI
+#[derive(Debug, Clone)]
+pub struct ThemeColors {
+    // Score-based colors (traffic light pattern)
+    pub score_high: Color,
+    pub score_mid: Color,
+    pub score_low: Color,
 
-/// Returns the appropriate color for a score based on its percentage of max score
-pub fn score_color(score: f64, max_score: f64) -> Color {
-    let percentage = if max_score > 0.0 {
-        (score / max_score) * 100.0
-    } else {
-        0.0
-    };
+    // Score bar colors
+    pub bar_filled_high: Color,
+    pub bar_filled_mid: Color,
+    pub bar_filled_low: Color,
+    pub bar_empty: Color,
 
-    if percentage >= 70.0 {
-        SCORE_HIGH
-    } else if percentage >= 40.0 {
-        SCORE_MID
-    } else {
-        SCORE_LOW
-    }
+    // Table colors
+    pub row_alt_bg: Color,
+    pub index_color: Color,
+
+    // Styles
+    pub title_style: Style,
+    pub header_style: Style,
+    pub tab_active: Style,
+    pub row_selected: Style,
+
+    // General colors
+    pub muted: Color,
+    pub title_color: Color,
+
+    // Tab colors
+    pub tab_active_style: Style,
+    pub tab_inactive_style: Style,
+
+    // Status bar colors
+    pub status_bar_bg: Color,
+    pub status_key_color: Color,
+    pub flash_success: Color,
+    pub flash_error: Color,
+
+    // Divider and separator colors
+    pub divider_color: Color,
+
+    // Popup overlay colors
+    pub popup_border: Color,
+    pub popup_title: Style,
+    pub popup_bg: Color,
+
+    // Scrollbar colors
+    pub scrollbar_thumb: Color,
+    pub scrollbar_track: Color,
+
+    // Update banner colors
+    pub banner_bg: Color,
+    pub banner_fg: Color,
+    pub banner_key: Color,
 }
 
-// Score bar colors (same thresholds as score text)
-pub const BAR_FILLED_HIGH: Color = Color::Red;
-pub const BAR_FILLED_MID: Color = Color::Yellow;
-pub const BAR_FILLED_LOW: Color = Color::Green;
-pub const BAR_EMPTY: Color = Color::DarkGray;
+impl ThemeColors {
+    /// Dark theme palette (reproduces original constants exactly)
+    pub fn dark() -> Self {
+        Self {
+            score_high: Color::Red,
+            score_mid: Color::Yellow,
+            score_low: Color::Green,
+            bar_filled_high: Color::Red,
+            bar_filled_mid: Color::Yellow,
+            bar_filled_low: Color::Green,
+            bar_empty: Color::DarkGray,
+            row_alt_bg: Color::Indexed(235),
+            index_color: Color::DarkGray,
+            title_style: Style::new().bold(),
+            header_style: Style::new().bold(),
+            tab_active: Style::new().reversed(),
+            row_selected: Style::new().reversed(),
+            muted: Color::Gray,
+            title_color: Color::Cyan,
+            tab_active_style: Style::new().fg(Color::Cyan).bold(),
+            tab_inactive_style: Style::new().fg(Color::DarkGray),
+            status_bar_bg: Color::Indexed(236),
+            status_key_color: Color::Cyan,
+            flash_success: Color::Green,
+            flash_error: Color::Red,
+            divider_color: Color::Indexed(238),
+            popup_border: Color::Cyan,
+            popup_title: Style::new().fg(Color::Cyan).bold(),
+            popup_bg: Color::Indexed(234),
+            scrollbar_thumb: Color::Indexed(244),
+            scrollbar_track: Color::Indexed(236),
+            banner_bg: Color::Rgb(50, 50, 120),
+            banner_fg: Color::White,
+            banner_key: Color::Yellow,
+        }
+    }
 
-// Table colors
-pub const ROW_ALT_BG: Color = Color::Indexed(235); // 256-color dark gray for alternating rows
-pub const INDEX_COLOR: Color = Color::DarkGray; // Index column color
+    /// Returns the appropriate color for a score based on its percentage of max score
+    pub fn score_color(&self, score: f64, max_score: f64) -> Color {
+        let percentage = if max_score > 0.0 {
+            (score / max_score) * 100.0
+        } else {
+            0.0
+        };
 
-// Styles
-pub const TITLE_STYLE: Style = Style::new().bold();
-pub const HEADER_STYLE: Style = Style::new().bold();
-pub const TAB_ACTIVE: Style = Style::new().reversed();
-pub const ROW_SELECTED: Style = Style::new().reversed();
-
-// General colors
-pub const MUTED: Color = Color::Gray; // For secondary text (ANSI 7, terminal-themed)
-
-// Title bar colors
-pub const TITLE_COLOR: Color = Color::Cyan; // Accent color for app name
-
-// Tab colors
-pub const TAB_ACTIVE_STYLE: Style = Style::new().fg(Color::Cyan).bold();
-pub const TAB_INACTIVE_STYLE: Style = Style::new().fg(Color::DarkGray);
-
-// Status bar colors
-pub const STATUS_BAR_BG: Color = Color::Indexed(236); // Subtle dark background
-pub const STATUS_KEY_COLOR: Color = Color::Cyan; // Keyboard shortcut hints
-pub const FLASH_SUCCESS: Color = Color::Green; // Positive flash messages
-pub const FLASH_ERROR: Color = Color::Red; // Error flash messages
-
-// Divider and separator colors
-pub const DIVIDER_COLOR: Color = Color::Indexed(238); // Subtle line color
-
-// Popup overlay colors
-pub const POPUP_BORDER: Color = Color::Cyan; // Accent color for popup borders
-pub const POPUP_TITLE: Style = Style::new().fg(Color::Cyan).bold();
-pub const POPUP_BG: Color = Color::Indexed(234); // Dark background for popup content
-
-// Scrollbar colors
-pub const SCROLLBAR_THUMB: Color = Color::Indexed(244); // Medium gray for scrollbar thumb
-pub const SCROLLBAR_TRACK: Color = Color::Indexed(236); // Dark gray for scrollbar track
-
-// Update banner colors
-pub const BANNER_BG: Color = Color::Rgb(50, 50, 120); // Dark blue-purple accent
-pub const BANNER_FG: Color = Color::White;
-pub const BANNER_KEY: Color = Color::Yellow; // Highlight for dismiss key hint
+        if percentage >= 70.0 {
+            self.score_high
+        } else if percentage >= 40.0 {
+            self.score_mid
+        } else {
+            self.score_low
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace scattered `pub const` color definitions in `theme.rs` with a `ThemeColors` struct
- Move `score_color()` from a free function to a `ThemeColors` method
- Wire all UI rendering through `app.theme_colors.*` instead of `theme::CONSTANT`

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (133 tests)
- [x] Visual verification: TUI renders identically to before (dark palette preserved exactly)

> **Stack:** 1/2 — next: `feat/light-dark-theme-support`

🤖 Generated with [Claude Code](https://claude.com/claude-code)