### PR TITLE
feat: add light and dark theme support with auto-detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "coolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,6 +2690,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
+ "terminal-light",
  "terminal_size",
  "tokio",
  "tokio-retry",
@@ -3731,6 +3738,18 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal-light"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f76be906d875a0ce764c52a055858c24847cb7dc674d3a5ad8cf7e3dd4ee9f"
+dependencies = [
+ "coolor",
+ "crossterm",
+ "thiserror 1.0.69",
+ "xterm-query",
 ]
 
 [[package]]
@@ -4823,6 +4842,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xterm-query"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292c33df434fde4ecd87a7afecdfa1681a3d29567fc69c774a0d83d32c095331"
+dependencies = [
+ "nix 0.29.0",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ cacache = "13"
 http = "1"
 glob = "0.3"
 semver = "1"
+terminal-light = "1.8"
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Use `pr-bro --help` for all command-line options. Press `?` in the TUI for keybo
 
 **Score breakdown** shows exactly how a PR's score was calculated. See which factors contributed most. Press `b` on any PR to open the detail view.
 
+**Light and dark themes** adapt to your terminal. PR Bro auto-detects your terminal background and picks the right color palette.
+
 **ETag-based HTTP caching** reduces GitHub API calls. Auto-refresh only fetches if data changed on the server. Manual refresh bypasses in-memory cache.
 
 ## Contributing

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,9 @@ Configuration file location: `~/.config/pr-bro/config.yaml`
 ## Full Configuration Example
 
 ```yaml
+# Theme: "auto" (default, detects terminal), "dark", or "light"
+theme: auto
+
 # Auto-refresh interval in seconds (default: 300 = 5 minutes)
 auto_refresh_interval: 300
 
@@ -207,6 +210,18 @@ In this example, the "urgent" query:
 ### YAML Merge Keys
 
 YAML merge keys (`<<:`) are supported by the YAML parser for reducing duplication within your config file. This is a YAML feature processed when reading the file, independent of the runtime merge that combines global and per-query scoring. Note that because PR Bro validates config structure strictly (`deny_unknown_fields`), YAML anchors must be placed inside fields that expect the anchored structure, not at the top level. For advanced YAML anchor/merge-key usage, refer to the [YAML specification](https://yaml.org/type/merge.html).
+
+## Theme
+
+PR Bro supports light and dark color themes. The default is `auto`, which detects your terminal's background color at startup and selects the appropriate palette.
+
+```yaml
+theme: auto    # Detect terminal background (default)
+theme: dark    # Always use dark theme
+theme: light   # Always use light theme
+```
+
+If auto-detection fails (e.g., over SSH or in tmux), it falls back to the dark theme.
 
 ## Config Validation
 

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -331,6 +331,7 @@ pub fn run_init_wizard(default_path: Option<PathBuf>) -> Result<()> {
         scoring: Some(scoring),
         queries,
         auto_refresh_interval: 300,
+        theme: "auto".to_string(),
     };
 
     let yaml = serde_saphyr::to_string(&config)

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6,6 +6,10 @@ fn default_refresh_interval() -> u64 {
     300
 }
 
+fn default_theme() -> String {
+    "auto".to_string()
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
@@ -18,6 +22,10 @@ pub struct Config {
     /// Auto-refresh interval in seconds (defaults to 300 = 5 minutes)
     #[serde(default = "default_refresh_interval")]
     pub auto_refresh_interval: u64,
+
+    /// Theme selection: "dark", "light", or "auto" (detects terminal background)
+    #[serde(default = "default_theme")]
+    pub theme: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,6 +233,9 @@ async fn main() {
     // Clean expired snoozes on load
     snooze_state.clean_expired();
 
+    // Resolve theme from config (before TUI mode, as terminal-light reads stdin)
+    let theme = pr_bro::tui::resolve_theme(&config.theme);
+
     // Check if any queries are configured
     if config.queries.is_empty() {
         eprintln!("No queries configured in config file.");
@@ -332,6 +335,7 @@ async fn main() {
             cli.verbose,
             auth_username.clone(),
             cli.no_version_check,
+            theme,
         );
 
         // Launch TUI immediately - it will trigger initial fetch in background

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3,7 +3,7 @@ use crate::github::cache::{CacheConfig, DiskCache};
 use crate::github::types::PullRequest;
 use crate::scoring::ScoreResult;
 use crate::snooze::SnoozeState;
-use crate::tui::theme::ThemeColors;
+use crate::tui::theme::{Theme, ThemeColors};
 use crate::version_check::VersionStatus;
 use chrono::{DateTime, Utc};
 use std::collections::VecDeque;
@@ -70,6 +70,7 @@ pub struct App {
     pub auth_username: Option<String>,
     pub version_status: VersionStatus,
     pub no_version_check: bool,
+    pub theme: Theme,
     pub theme_colors: ThemeColors,
 }
 
@@ -86,6 +87,7 @@ impl App {
         verbose: bool,
         auth_username: Option<String>,
         no_version_check: bool,
+        theme: Theme,
     ) -> Self {
         let mut table_state = ratatui::widgets::TableState::default();
         if !active_prs.is_empty() {
@@ -117,7 +119,8 @@ impl App {
             auth_username,
             version_status: VersionStatus::Unknown,
             no_version_check,
-            theme_colors: ThemeColors::dark(),
+            theme,
+            theme_colors: ThemeColors::new(theme),
         }
     }
 
@@ -133,6 +136,7 @@ impl App {
         verbose: bool,
         auth_username: Option<String>,
         no_version_check: bool,
+        theme: Theme,
     ) -> Self {
         Self {
             active_prs: Vec::new(),
@@ -159,7 +163,8 @@ impl App {
             auth_username,
             version_status: VersionStatus::Unknown,
             no_version_check,
-            theme_colors: ThemeColors::dark(),
+            theme,
+            theme_colors: ThemeColors::new(theme),
         }
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4,7 +4,7 @@ pub mod theme;
 pub mod ui;
 
 pub use app::App;
-pub use theme::ThemeColors;
+pub use theme::{resolve_theme, Theme, ThemeColors};
 
 use std::time::Duration;
 


### PR DESCRIPTION
## Summary
- Add `Theme` enum (Light/Dark) and light color palette to `ThemeColors`
- Auto-detect terminal background using `terminal-light` crate (luminance-based)
- Add `theme` config field (`"auto"` / `"dark"` / `"light"`, default: `"auto"`)
- Update documentation (README, configuration guide)

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (133 tests)
- [x] Visual verification on dark terminal
- [x] Visual verification on light terminal
- [x] Verify `theme: auto` correctly detects terminal background
- [x] Verify `theme: dark` and `theme: light` overrides work

> **Stack:** 2/2 — depends on #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Inspired by #68 