### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/toniperic/pr-bro/compare/v0.3.4...v0.4.0) - 2026-02-11
+
+### Added
+
+- add light and dark theme support with auto-detection
+
+### Other
+
+- disable duplicate GitHub auto-generated release notes
+- replace theme constants with ThemeColors struct
+
 ## [0.3.4](https://github.com/toniperic/pr-bro/compare/v0.3.3...v0.3.4) - 2026-02-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "pr-bro"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "atomic-write-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr-bro"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 description = "Know which PR to review next. Ranks pull requests by weighted scoring."
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `pr-bro`: 0.3.4 -> 0.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/toniperic/pr-bro/compare/v0.3.4...v0.4.0) - 2026-02-11

### Added

- add light and dark theme support with auto-detection

### Other

- disable duplicate GitHub auto-generated release notes
- replace theme constants with ThemeColors struct
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).