### PR TITLE
chore: disable duplicate GitHub auto-generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          generate_release_notes: false
           prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
           files: dist/*
           fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary
- release-plz already populates the GitHub release body with changelog content
- The `generate_release_notes: true` flag in the release workflow was causing `softprops/action-gh-release` to append GitHub's auto-generated "What's Changed" section on top of that, resulting in duplicate summaries
- Set `generate_release_notes: false` to fix

## Test plan
- [ ] Merge and verify next release only contains release-plz changelog (no duplicate "What's Changed" section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)