### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/toniperic/pr-bro/compare/v0.4.0...v0.4.1) - 2026-02-11
+
+### Other
+
+- replace hardcoded help text padding with programmatic alignment
+
 ## [0.4.0](https://github.com/toniperic/pr-bro/compare/v0.3.4...v0.4.0) - 2026-02-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "pr-bro"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "atomic-write-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr-bro"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Know which PR to review next. Ranks pull requests by weighted scoring."
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `pr-bro`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/toniperic/pr-bro/compare/v0.4.0...v0.4.1) - 2026-02-11

### Other

- replace hardcoded help text padding with programmatic alignment
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).