### PR TITLE
ci: remove refactor commits from release-plz triggers

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,7 +4,7 @@ git_release_type = "auto"
 semver_check = false
 features_always_increment_minor = true
 pr_labels = ["release"]
-release_commits = "^(feat|fix|perf|refactor)[(:]"
+release_commits = "^(feat|fix|perf)[(:]"
 
 [changelog]
 protect_breaking_commits = true


### PR DESCRIPTION
## Summary
- Remove `refactor` from the `release_commits` regex in `release-plz.toml`
- Refactor commits have no user-visible change, so they shouldn't trigger a patch release
- `feat`, `fix`, and `perf` remain as release triggers

## Test plan
- [ ] Verify release-plz no longer opens release PRs for refactor-only commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)