### PR TITLE
docs: fix overlapping size bucket range in config example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ scoring:
         effect: "x10"     # Extremely small PRs get a huge boost
       - range: "10-99"
         effect: "x5"      # Small PRS get a decent boost
-      - range: "100-250"
+      - range: "100-249"
         effect: "x1"      # Medium PRs: no change
       - range: "250-499"
         effect: "x0.5"    # Large PRs get a decent penalty


### PR DESCRIPTION
## Summary
- The Full Configuration Example in `docs/configuration.md` had overlapping size buckets: `100-250` and `250-499` both matched value 250
- Fixed by changing the first range to `100-249` so buckets are contiguous without overlap
- This prevents users from copy-pasting an invalid config that would be rejected by startup validation

## Test plan
- [ ] Verify the example buckets (`0-9`, `10-99`, `100-249`, `250-499`, `>=500`) have no gaps or overlaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)