### PR TITLE
fix: suppress auto-refresh during TUI interaction

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -72,6 +72,7 @@ pub struct App {
     pub no_version_check: bool,
     pub theme: Theme,
     pub theme_colors: ThemeColors,
+    pub last_interaction: Instant,
 }
 
 impl App {
@@ -121,6 +122,7 @@ impl App {
             no_version_check,
             theme,
             theme_colors: ThemeColors::new(theme),
+            last_interaction: Instant::now(),
         }
     }
 
@@ -165,6 +167,7 @@ impl App {
             no_version_check,
             theme,
             theme_colors: ThemeColors::new(theme),
+            last_interaction: Instant::now(),
         }
     }
 


### PR DESCRIPTION
## Summary
- Suppress auto-refresh while a modal is open (Help, Snooze, Score Breakdown)
- Suppress auto-refresh for 10 seconds after any keypress
- Manual refresh ('r' key) always works regardless of suppression
- Deferred refreshes fire once conditions clear (`needs_refresh` stays `true`)

## Test plan
- [ ] Open score breakdown modal, wait for auto-refresh interval — list should not refresh
- [ ] Open snooze modal, wait — list should not refresh
- [ ] Navigate with j/k keys, verify no refresh fires within 10s of last keypress
- [ ] Press 'r' while navigating — manual refresh should work immediately
- [ ] Leave TUI idle for >10s with no modal — auto-refresh should fire normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)