### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/toniperic/pr-bro/compare/v0.4.1...v0.4.2) - 2026-03-05
+
+### Fixed
+
+- *(deps)* bump aws-lc-sys from 0.37.0 to 0.38.0
+
+### Other
+
+- *(deps)* bump tokio from 1.49.0 to 1.50.0
+- *(deps)* bump serde-saphyr from 0.0.20 to 0.0.21
+- *(deps)* bump actions/download-artifact from 7 to 8
+- *(deps)* bump actions/upload-artifact from 6 to 7
+- *(deps)* bump rustls from 0.23.36 to 0.23.37
+- *(deps)* bump chrono from 0.4.43 to 0.4.44
+- *(deps)* bump serde-saphyr from 0.0.19 to 0.0.20
+
 ## [0.4.1](https://github.com/toniperic/pr-bro/compare/v0.4.0...v0.4.1) - 2026-02-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "pr-bro"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "atomic-write-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr-bro"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Know which PR to review next. Ranks pull requests by weighted scoring."
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `pr-bro`: 0.4.1 -> 0.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.2](https://github.com/toniperic/pr-bro/compare/v0.4.1...v0.4.2) - 2026-03-05

### Fixed

- *(deps)* bump aws-lc-sys from 0.37.0 to 0.38.0

### Other

- *(deps)* bump tokio from 1.49.0 to 1.50.0
- *(deps)* bump serde-saphyr from 0.0.20 to 0.0.21
- *(deps)* bump actions/download-artifact from 7 to 8
- *(deps)* bump actions/upload-artifact from 6 to 7
- *(deps)* bump rustls from 0.23.36 to 0.23.37
- *(deps)* bump chrono from 0.4.43 to 0.4.44
- *(deps)* bump serde-saphyr from 0.0.19 to 0.0.20
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).