### PR TITLE
feat: add draft PR scoring factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Use `pr-bro --help` for all command-line options. Press `?` in the TUI for keybo
 
 ## Features
 
-**Weighted scoring** calculates a single priority number for each PR based on age, approval count, size, labels, and whether you've reviewed it before, all based on your preferences/configuration. Each parameter can be used to boost or penalize PRs score in any way you see fit.
+**Weighted scoring** calculates a single priority number for each PR based on age, approval count, size, labels, draft status, and whether you've reviewed it before, all based on your preferences/configuration. Each parameter can be used to boost or penalize PRs score in any way you see fit.
 
 **Interactive TUI** shows all PRs sorted by score. Navigate with arrow keys or vim bindings. Press `b` to see the score breakdown for any PR. Press `r` to refresh.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,7 @@ scoring:
     - name: "wip"
       effect: "x0.5"
   previously_reviewed: "x2.5"  # Previously reviewed PRs get a boost
+  draft: "x0.1"               # Deprioritize draft PRs
 
 # Queries to execute (at least one required)
 queries:
@@ -144,6 +145,14 @@ That workflow, paired with this configuration, means that when they need you to 
 previously_reviewed: "x2.5"   # Prioritize already-reviewed PRs
 ```
 
+### Draft
+
+Optional. Applies a score effect when a PR is marked as a draft. Useful for deprioritizing PRs that aren't ready for review yet.
+
+```yaml
+draft: "x0.1"   # Heavily deprioritize draft PRs
+```
+
 ## Effect Syntax Summary
 
 | Syntax | Meaning |
@@ -155,7 +164,7 @@ previously_reviewed: "x2.5"   # Prioritize already-reviewed PRs
 | `+N per M` | Add N points per M units (approvals only) |
 | `xN per M` | Multiply by N per M units (approvals only) |
 
-Labels and previously_reviewed use flat effects (`+N` or `xN`), not per-unit effects.
+Labels, previously_reviewed, and draft use flat effects (`+N` or `xN`), not per-unit effects.
 
 ## Per-Query Scoring
 
@@ -205,7 +214,7 @@ In this example, the "urgent" query:
 - **Overrides** `age` to `"+10 per 1h"` (urgent PRs age faster).
 - **Adds** `size.exclude` with `["*.lock"]`. Because merging is leaf-level, global `size.buckets` are inherited — setting `size.exclude` does NOT replace the entire `size` block.
 - **Overrides** the "urgent" label effect from `"+20"` to `"+50"`. Labels merge by name (case-insensitive): the query's "urgent" label wins over the global one. The global "wip" label is preserved because the query does not mention it.
-- **Inherits** `base_score`, `approvals`, and `previously_reviewed` from the global config (not specified in the query, so global values apply).
+- **Inherits** `base_score`, `approvals`, `previously_reviewed`, and `draft` from the global config (not specified in the query, so global values apply).
 
 ### YAML Merge Keys
 
@@ -232,6 +241,6 @@ PR Bro validates your configuration at startup with clear error messages:
 - **Invalid effect syntax** is caught with helpful messages
 - **Empty label names** are rejected
 - **Invalid glob patterns** in `size.exclude` are caught (e.g., unclosed character classes like `[invalid`)
-- **Invalid label effects** and **invalid previously_reviewed effects** are caught at startup
+- **Invalid label effects**, **invalid previously_reviewed effects**, and **invalid draft effects** are caught at startup
 
 Validation errors will show exactly what's wrong and where, so you can fix configuration issues quickly.

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -209,6 +209,22 @@ pub fn run_init_wizard(default_path: Option<PathBuf>) -> Result<()> {
             }
         };
 
+        // Draft
+        println!();
+        typewriter("Draft PRs aren't ready for review yet. You can deprioritize them.");
+        typewriter("Use 'x0.1' to heavily deprioritize, or 'x0.5' for a lighter penalty.");
+        typewriter("Use 'none' to skip this factor entirely.");
+        let draft = loop {
+            let input = prompt_with_default("Draft factor (e.g., x0.1 to deprioritize)", "none")?;
+            if input == "none" || input.is_empty() {
+                break None;
+            }
+            match Effect::parse(&input) {
+                Ok(_) => break Some(input),
+                Err(e) => println!("  Invalid: {}. Try again.", e),
+            }
+        };
+
         // Labels
         println!();
         typewriter("Labels let you boost or penalize PRs based on GitHub labels.");
@@ -252,6 +268,7 @@ pub fn run_init_wizard(default_path: Option<PathBuf>) -> Result<()> {
             size,
             labels,
             previously_reviewed,
+            draft,
         }
     } else {
         ScoringConfig::default()

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -211,8 +211,8 @@ pub fn run_init_wizard(default_path: Option<PathBuf>) -> Result<()> {
 
         // Draft
         println!();
-        typewriter("Draft PRs aren't ready for review yet. You can deprioritize them.");
-        typewriter("Use 'x0.1' to heavily deprioritize, or 'x0.5' for a lighter penalty.");
+        typewriter("If you value drafts differently compared to pull requests, you can (de)prioritize them.");
+        typewriter("For example, use 'x0.1' to heavily deprioritize, 'x0.5' for a lighter penalty or 'x1.5' if you want to give them a boost.");
         typewriter("Use 'none' to skip this factor entirely.");
         let draft = loop {
             let input = prompt_with_default("Draft factor (e.g., x0.1 to deprioritize)", "none")?;

--- a/src/github/search.rs
+++ b/src/github/search.rs
@@ -57,7 +57,7 @@ pub async fn search_prs(client: &Octocrab, query: &str) -> Result<Vec<PullReques
                             additions: 0, // Search API doesn't include these
                             deletions: 0, // Will be populated by enrichment
                             approvals: 0, // Requires separate API call
-                            draft: false, // Search API doesn't expose draft status reliably
+                            draft: false, // Populated during enrichment from Pulls API
                             labels: issue.labels.iter().map(|l| l.name.clone()).collect(),
                             user_has_reviewed: false, // Will be populated by enrichment
                             filtered_size: None, // Will be set by enrich_pr if exclude patterns configured
@@ -115,7 +115,7 @@ async fn fetch_pr_details(
     owner: &str,
     repo: &str,
     number: u64,
-) -> Result<(u64, u64)> {
+) -> Result<(u64, u64, bool)> {
     let pr = client
         .pulls(owner, repo)
         .get(number)
@@ -124,8 +124,9 @@ async fn fetch_pr_details(
 
     let additions = pr.additions.unwrap_or(0);
     let deletions = pr.deletions.unwrap_or(0);
+    let draft = pr.draft.unwrap_or(false);
 
-    Ok((additions, deletions))
+    Ok((additions, deletions, draft))
 }
 
 /// Fetch PR review count (approved reviews) and check if authenticated user has reviewed
@@ -233,9 +234,10 @@ async fn enrich_pr(
     let reviews_fut = fetch_pr_reviews(client, owner, repo_name, pr.number, auth_username);
 
     match tokio::try_join!(details_fut, reviews_fut) {
-        Ok(((additions, deletions), (approvals, user_has_reviewed))) => {
+        Ok(((additions, deletions, draft), (approvals, user_has_reviewed))) => {
             pr.additions = additions;
             pr.deletions = deletions;
+            pr.draft = draft;
             pr.approvals = approvals;
             pr.user_has_reviewed = user_has_reviewed;
 

--- a/src/scoring/config.rs
+++ b/src/scoring/config.rs
@@ -68,6 +68,11 @@ pub struct ScoringConfig {
     /// Example: "x0.5" to deprioritize previously-reviewed PRs
     #[serde(default)]
     pub previously_reviewed: Option<String>,
+
+    /// Draft factor: effect applied when PR is a draft
+    /// Example: "x0.1" to deprioritize draft PRs
+    #[serde(default)]
+    pub draft: Option<String>,
 }
 
 impl Default for ScoringConfig {
@@ -95,6 +100,7 @@ impl Default for ScoringConfig {
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         }
     }
 }
@@ -121,6 +127,7 @@ pub fn merge_scoring_configs(
             .previously_reviewed
             .clone()
             .or_else(|| global.previously_reviewed.clone()),
+        draft: query.draft.clone().or_else(|| global.draft.clone()),
     }
 }
 
@@ -328,6 +335,15 @@ previously_reviewed: "x0.5"
     }
 
     #[test]
+    fn test_draft_config_parse() {
+        let yaml = r#"
+draft: "x0.1"
+"#;
+        let config: ScoringConfig = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(config.draft, Some("x0.1".to_string()));
+    }
+
+    #[test]
     fn test_full_config_with_all_factors() {
         let yaml = r#"
 base_score: 100
@@ -341,6 +357,7 @@ labels:
   - name: "urgent"
     effect: "+20"
 previously_reviewed: "x0.5"
+draft: "x0.1"
 "#;
         let config: ScoringConfig = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(config.base_score, Some(100.0));
@@ -349,6 +366,7 @@ previously_reviewed: "x0.5"
         assert!(config.size.is_some());
         assert_eq!(config.labels.as_ref().unwrap().len(), 1);
         assert_eq!(config.previously_reviewed, Some("x0.5".to_string()));
+        assert_eq!(config.draft, Some("x0.1".to_string()));
     }
 
     // --- Merge function tests ---
@@ -378,6 +396,7 @@ previously_reviewed: "x0.5"
                 effect: "+10".to_string(),
             }]),
             previously_reviewed: Some("x0.5".to_string()),
+            draft: None,
         };
 
         // Query only sets age — everything else should come from global
@@ -388,6 +407,7 @@ previously_reviewed: "x0.5"
             size: None,
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = merge_scoring_configs(&global, Some(&query));
@@ -412,6 +432,7 @@ previously_reviewed: "x0.5"
             size: None,
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let query = ScoringConfig {
@@ -421,6 +442,7 @@ previously_reviewed: "x0.5"
             size: None,
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = merge_scoring_configs(&global, Some(&query));
@@ -443,6 +465,7 @@ previously_reviewed: "x0.5"
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         // Query has size with new buckets but no exclude
@@ -459,6 +482,7 @@ previously_reviewed: "x0.5"
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = merge_scoring_configs(&global, Some(&query));
@@ -486,6 +510,7 @@ previously_reviewed: "x0.5"
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         // Query has size with absent buckets (None = inherit)
@@ -499,6 +524,7 @@ previously_reviewed: "x0.5"
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = merge_scoring_configs(&global, Some(&query));
@@ -521,6 +547,7 @@ previously_reviewed: "x0.5"
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let query = ScoringConfig {
@@ -533,6 +560,7 @@ previously_reviewed: "x0.5"
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = merge_scoring_configs(&global, Some(&query));
@@ -553,6 +581,7 @@ previously_reviewed: "x0.5"
             size: None,
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = merge_scoring_configs(&global, Some(&query));
@@ -578,6 +607,7 @@ previously_reviewed: "x0.5"
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let query = ScoringConfig {
@@ -590,6 +620,7 @@ previously_reviewed: "x0.5"
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = merge_scoring_configs(&global, Some(&query));
@@ -615,6 +646,7 @@ previously_reviewed: "x0.5"
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let query = ScoringConfig {
@@ -630,6 +662,7 @@ previously_reviewed: "x0.5"
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = merge_scoring_configs(&global, Some(&query));
@@ -656,6 +689,7 @@ previously_reviewed: "x0.5"
                 effect: "x3".to_string(),
             }]),
             previously_reviewed: None,
+            draft: None,
         };
 
         let query = ScoringConfig {
@@ -668,6 +702,7 @@ previously_reviewed: "x0.5"
                 effect: "x2".to_string(),
             }]),
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = merge_scoring_configs(&global, Some(&query));
@@ -695,6 +730,7 @@ previously_reviewed: "x0.5"
                 },
             ]),
             previously_reviewed: None,
+            draft: None,
         };
 
         let query = ScoringConfig {
@@ -707,6 +743,7 @@ previously_reviewed: "x0.5"
                 effect: "+20".to_string(),
             }]),
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = merge_scoring_configs(&global, Some(&query));
@@ -731,6 +768,7 @@ previously_reviewed: "x0.5"
                 effect: "+10".to_string(),
             }]),
             previously_reviewed: None,
+            draft: None,
         };
 
         let query = ScoringConfig {
@@ -743,6 +781,7 @@ previously_reviewed: "x0.5"
                 effect: "+20".to_string(),
             }]),
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = merge_scoring_configs(&global, Some(&query));
@@ -762,6 +801,7 @@ previously_reviewed: "x0.5"
             size: None,
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let query = ScoringConfig {
@@ -774,6 +814,7 @@ previously_reviewed: "x0.5"
                 effect: "+5".to_string(),
             }]),
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = merge_scoring_configs(&global, Some(&query));
@@ -794,6 +835,7 @@ previously_reviewed: "x0.5"
                 effect: "+10".to_string(),
             }]),
             previously_reviewed: None,
+            draft: None,
         };
 
         let query = ScoringConfig {
@@ -803,6 +845,7 @@ previously_reviewed: "x0.5"
             size: None,
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = merge_scoring_configs(&global, Some(&query));

--- a/src/scoring/engine.rs
+++ b/src/scoring/engine.rs
@@ -148,6 +148,22 @@ pub fn calculate_score(pr: &PullRequest, config: &ScoringConfig) -> ScoreResult 
         }
     }
 
+    // Apply draft factor
+    if let Some(ref draft_effect_str) = config.draft {
+        if pr.draft {
+            if let Ok(effect) = Effect::parse(draft_effect_str) {
+                let before = score;
+                score = effect.apply(score, 1);
+                factors.push(FactorContribution {
+                    label: "Draft".to_string(),
+                    description: format!("PR is a draft -> {}", draft_effect_str),
+                    before,
+                    after: score,
+                });
+            }
+        }
+    }
+
     // Floor at zero
     ScoreResult {
         score: score.max(0.0),
@@ -251,6 +267,7 @@ mod tests {
                 size: None,
                 labels: None,
                 previously_reviewed: None,
+                draft: None,
             },
         );
         assert_eq!(result.score, 100.0);
@@ -269,6 +286,7 @@ mod tests {
                 size: None,
                 labels: None,
                 previously_reviewed: None,
+                draft: None,
             },
         );
         assert_eq!(result.score, 105.0); // 100 + 5*1
@@ -286,6 +304,7 @@ mod tests {
                 size: None,
                 labels: None,
                 previously_reviewed: None,
+                draft: None,
             },
         );
         assert_eq!(result.score, 0.0);
@@ -303,6 +322,7 @@ mod tests {
                 size: None,
                 labels: None,
                 previously_reviewed: None,
+                draft: None,
             },
         );
         assert_eq!(result.score, 50.0);
@@ -326,6 +346,7 @@ mod tests {
                 }),
                 labels: None,
                 previously_reviewed: None,
+                draft: None,
             },
         );
         assert_eq!(result.score, 200.0);
@@ -355,6 +376,7 @@ mod tests {
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = calculate_score(&pr, &config);
@@ -385,6 +407,7 @@ mod tests {
             size: None,
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = calculate_score(&pr, &config);
@@ -415,6 +438,7 @@ mod tests {
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = calculate_score(&pr, &config);
@@ -436,6 +460,7 @@ mod tests {
                 effect: "+10".to_string(),
             }]),
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = calculate_score(&pr, &config);
@@ -457,6 +482,7 @@ mod tests {
                 effect: "x0.5".to_string(),
             }]),
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = calculate_score(&pr, &config);
@@ -480,6 +506,7 @@ mod tests {
                 }, // lowercase
             ]),
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = calculate_score(&pr, &config);
@@ -507,6 +534,7 @@ mod tests {
                 },
             ]),
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = calculate_score(&pr, &config);
@@ -529,6 +557,7 @@ mod tests {
                 effect: "+10".to_string(),
             }]),
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = calculate_score(&pr, &config);
@@ -547,6 +576,7 @@ mod tests {
             size: None,
             labels: None,
             previously_reviewed: Some("x0.5".to_string()),
+            draft: None,
         };
 
         let result = calculate_score(&pr, &config);
@@ -565,6 +595,7 @@ mod tests {
             size: None,
             labels: None,
             previously_reviewed: Some("x0.5".to_string()),
+            draft: None,
         };
 
         let result = calculate_score(&pr, &config);
@@ -595,6 +626,7 @@ mod tests {
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
 
         let result = calculate_score(&pr, &config);
@@ -624,11 +656,50 @@ mod tests {
                 effect: "+20".to_string(),
             }]),
             previously_reviewed: Some("x0.5".to_string()),
+            draft: None,
         };
 
         let result = calculate_score(&pr, &config);
         // (100 + 5 + 20) * 2 + 20 = 270
         // Wait, order: base=100, age=+5 (105), approvals=+20 (125), size=x2 (250), labels=+20 (270), previously_reviewed not applied (false)
         assert_eq!(result.score, 270.0);
+    }
+
+    #[test]
+    fn test_draft_applies() {
+        let mut pr = sample_pr(1, 0, 100);
+        pr.draft = true;
+
+        let config = ScoringConfig {
+            base_score: Some(100.0),
+            age: None,
+            approvals: None,
+            size: None,
+            labels: None,
+            previously_reviewed: None,
+            draft: Some("x0.1".to_string()),
+        };
+
+        let result = calculate_score(&pr, &config);
+        assert!((result.score - 10.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_draft_not_applied_when_not_draft() {
+        let mut pr = sample_pr(1, 0, 100);
+        pr.draft = false;
+
+        let config = ScoringConfig {
+            base_score: Some(100.0),
+            age: None,
+            approvals: None,
+            size: None,
+            labels: None,
+            previously_reviewed: None,
+            draft: Some("x0.1".to_string()),
+        };
+
+        let result = calculate_score(&pr, &config);
+        assert_eq!(result.score, 100.0);
     }
 }

--- a/src/scoring/validation.rs
+++ b/src/scoring/validation.rs
@@ -106,6 +106,13 @@ pub fn validate_scoring(config: &ScoringConfig) -> Result<(), Vec<String>> {
         }
     }
 
+    // Validate draft effect
+    if let Some(ref draft) = config.draft {
+        if let Err(e) = Effect::parse(draft) {
+            errors.push(format!("scoring.draft: invalid '{}' - {}", draft, e));
+        }
+    }
+
     if errors.is_empty() {
         Ok(())
     } else {
@@ -186,6 +193,7 @@ mod tests {
             size: None,
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         assert!(validate_scoring(&config).is_ok());
     }
@@ -199,6 +207,7 @@ mod tests {
             size: None,
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         assert!(validate_scoring(&config).is_ok());
     }
@@ -212,6 +221,7 @@ mod tests {
             size: None,
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         let result = validate_scoring(&config);
         assert!(result.is_err());
@@ -228,6 +238,7 @@ mod tests {
             size: None,
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         let result = validate_scoring(&config);
         assert!(result.is_err());
@@ -244,6 +255,7 @@ mod tests {
             size: None,
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         let result = validate_scoring(&config);
         assert!(result.is_err());
@@ -266,6 +278,7 @@ mod tests {
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         let result = validate_scoring(&config);
         assert!(result.is_err());
@@ -282,6 +295,7 @@ mod tests {
             size: None,
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         let result = validate_scoring(&config);
         assert!(result.is_err());
@@ -322,6 +336,7 @@ mod tests {
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         assert!(validate_scoring(&config).is_ok());
     }
@@ -347,6 +362,7 @@ mod tests {
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         let result = validate_scoring(&config);
         assert!(result.is_err());
@@ -377,6 +393,7 @@ mod tests {
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         let result = validate_scoring(&config);
         assert!(result.is_err());
@@ -405,6 +422,7 @@ mod tests {
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         assert!(validate_scoring(&config).is_ok());
     }
@@ -430,6 +448,7 @@ mod tests {
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         let result = validate_scoring(&config);
         assert!(result.is_err());
@@ -458,6 +477,7 @@ mod tests {
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         let result = validate_scoring(&config);
         assert!(result.is_err());
@@ -486,6 +506,7 @@ mod tests {
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         assert!(validate_scoring(&config).is_ok());
     }
@@ -508,6 +529,7 @@ mod tests {
                 },
             ]),
             previously_reviewed: None,
+            draft: None,
         };
         assert!(validate_scoring(&config).is_ok());
     }
@@ -524,6 +546,7 @@ mod tests {
                 effect: "bad".to_string(),
             }]),
             previously_reviewed: None,
+            draft: None,
         };
         let result = validate_scoring(&config);
         assert!(result.is_err());
@@ -544,6 +567,7 @@ mod tests {
                 effect: "+10".to_string(),
             }]),
             previously_reviewed: None,
+            draft: None,
         };
         let result = validate_scoring(&config);
         assert!(result.is_err());
@@ -561,6 +585,7 @@ mod tests {
             size: None,
             labels: None,
             previously_reviewed: Some("x0.5".to_string()),
+            draft: None,
         };
         assert!(validate_scoring(&config).is_ok());
     }
@@ -574,6 +599,7 @@ mod tests {
             size: None,
             labels: None,
             previously_reviewed: Some("invalid".to_string()),
+            draft: None,
         };
         let result = validate_scoring(&config);
         assert!(result.is_err());
@@ -597,6 +623,7 @@ mod tests {
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         assert!(validate_scoring(&config).is_ok());
     }
@@ -616,6 +643,7 @@ mod tests {
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         let result = validate_scoring(&config);
         assert!(result.is_err());
@@ -639,6 +667,7 @@ mod tests {
             }),
             labels: None,
             previously_reviewed: None,
+            draft: None,
         };
         let result = validate_scoring(&config);
         assert!(result.is_err());
@@ -662,6 +691,7 @@ mod tests {
                 }, // Error 3 & 4
             ]),
             previously_reviewed: Some("invalid".to_string()), // Error 5
+            draft: None,
         };
         let result = validate_scoring(&config);
         assert!(result.is_err());


### PR DESCRIPTION
fixes: https://github.com/toniperic/pr-bro/issues/95

I asked copilot to help build out the draft scoring feature. Feel free to make updates/changes. Sharing in hopes it may be helpful.

>  Adds support for scoring draft PRs using the same effect syntax as
>  previously_reviewed. Users can configure it like:
>
>   scoring:
>     draft: "x0.1"
>
>  How it works
>
>  The Search API (/search/issues) returns issue-shaped objects that don't
>  include draft status — hence the existing draft: false hardcode with the
>  comment "Search API doesn't expose draft status reliably".
>
>  However, the enrichment step already calls the Pulls API (https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request)
> (/repos/{owner}/{repo}/pulls/{number}) to fetch additions and deletions. This
>  endpoint reliably returns draft, and octocrab already models it as draft:
>  Option<bool> (https://docs.rs/octocrab/latest/octocrab/models/pulls/struct.PullRequest.html#structfield.draft). 
>  This PR extracts it during enrichment — zero additional API calls.
>
>  Changes
>
>   - src/github/search.rs: fetch_pr_details now returns (u64, u64, bool)
>  including draft status; enrich_pr populates pr.draft from the result
>   - src/scoring/config.rs: Added draft: Option<String> to ScoringConfig with
>  default/merge support
>   - src/scoring/engine.rs: Added draft scoring factor (applied after labels,
>  mirrors previously_reviewed pattern)
>   - src/scoring/validation.rs: Added draft effect validation
>   - src/config/init.rs: Added draft prompt to init wizard
>   - docs/configuration.md and README.md: Updated documentation
>
>  3 new tests, all 136 tests passing.
