### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/toniperic/pr-bro/compare/v0.4.2...v0.5.0) - 2026-03-10
+
+### Added
+
+- add draft PR scoring factor ([#96](https://github.com/toniperic/pr-bro/pull/96))
+
+### Other
+
+- *(deps)* bump webbrowser from 1.1.0 to 1.2.0
+
 ## [0.4.2](https://github.com/toniperic/pr-bro/compare/v0.4.1...v0.4.2) - 2026-03-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "pr-bro"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "atomic-write-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr-bro"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 description = "Know which PR to review next. Ranks pull requests by weighted scoring."
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `pr-bro`: 0.4.2 -> 0.5.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/toniperic/pr-bro/compare/v0.4.2...v0.5.0) - 2026-03-10

### Added

- add draft PR scoring factor ([#96](https://github.com/toniperic/pr-bro/pull/96))

### Other

- *(deps)* bump webbrowser from 1.1.0 to 1.2.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).