### PR TITLE
fix: resolve clippy lints from Rust 1.95

### DIFF
--- a/src/scoring/engine.rs
+++ b/src/scoring/engine.rs
@@ -179,11 +179,7 @@ fn calculate_units(effect: &Effect, age: chrono::Duration) -> u64 {
     if let Some(unit_duration) = effect.unit_duration() {
         let age_secs = age.num_seconds().max(0) as u64;
         let unit_secs = unit_duration.as_secs();
-        if unit_secs > 0 {
-            age_secs / unit_secs
-        } else {
-            0
-        }
+        age_secs.checked_div(unit_secs).unwrap_or(0)
     } else {
         1 // Non-per-unit effects apply once
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -291,10 +291,8 @@ fn handle_key_event(app: &mut App, key: KeyEvent) {
                 KeyCode::Char('b') => app.show_score_breakdown(),
 
                 // Dismiss update banner
-                KeyCode::Char('x') => {
-                    if app.has_update_banner() {
-                        app.dismiss_update_banner();
-                    }
+                KeyCode::Char('x') if app.has_update_banner() => {
+                    app.dismiss_update_banner();
                 }
 
                 _ => {}


### PR DESCRIPTION
## Summary
- Replace manual checked division with `checked_div` in `src/scoring/engine.rs:182`
- Collapse nested `if` into match arm guard in `src/tui/mod.rs:295`

Both lints are new in Rust 1.95 and currently break CI on every open PR (e.g. #115).

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes locally
- [x] `cargo test --all-features` passes (136 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)