### PR TITLE
chore(deps): bump rand from 0.9.2 to 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84790c55b5704b0d35130bf16a4ce22a8e70eb0ea773522557524d9a4852663d"
 dependencies = [
  "nix 0.30.1",
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]
@@ -2693,7 +2693,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2753,9 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",


### PR DESCRIPTION
## Summary

Bumps the locked rand dependency from 0.9.2 to 0.9.3 to address Dependabot alert 15 / GHSA-cq8v-f236-94qc.

The vulnerable rand version is pulled in through atomic-write-file; this lockfile update keeps the dependency on the patched 0.9.x release.

## Validation

- cargo test